### PR TITLE
$ZRAM_GENERATOR_ROOT, swap priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ This program serves two purposes:
 
 2. Once we figure out all the details, it should be useful as an
    example of a systemd generator in rust.
+
+### Testing
+
+Set the `ZRAM_GENERATOR_ROOT` environment variable to use that
+instead of `/` as root.

--- a/TODO
+++ b/TODO
@@ -1,8 +1,6 @@
 - instead of using the shell in the service file, consider calling the generator
   binary again and doing the initalization from it.
 - logging in generators needs to go to kmsg, println!() is not enough.
-- add a testing mode where, if $ZRAM_GENERATOR_ROOT=... is set, and do everything
-  relative to this path then.
 - figure out how to tell cargo to install into
   /usr/lib/systemd/system-generators not /usr/bin
 - make swap priority configurable?

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,13 @@ extern crate ini;
 
 use failure::Error;
 use ini::Ini;
+use std::borrow::Cow;
 use std::env;
 use std::fmt;
 use std::fs;
 use std::io::prelude::*;
 use std::os::unix::fs::symlink;
-use std::path::{Path, PathBuf};
+use std::path::{self, Path, PathBuf};
 use std::process::Command;
 use std::result;
 
@@ -48,8 +49,17 @@ fn virtualization_container() -> Result<bool, Error> {
 }
 
 fn main() {
+    let root: Cow<'static, str> =
+        env::var("ZRAM_GENERATOR_ROOT").map(|mut root| {
+            if !root.ends_with(path::is_separator) {
+                root.push('/');
+            }
+            println!("Using {:?} as root directory", root);
+            root.into()
+        }).unwrap_or("/".into());
+
     let args: Vec<String> = env::args().collect();
-    let config = match Config::new(&args) {
+    let config = match Config::new(&args, root) {
         Ok(ok) => ok,
         Err(e) => {
             println!("{}", e);
@@ -85,13 +95,15 @@ impl Device {
 }
 
 struct Config {
+    root: Cow<'static, str>,
+
     output_directory: PathBuf,
 
     devices: Vec<Device>,
 }
 
 impl Config {
-    fn new(args: &[String]) -> Result<Config, Error> {
+    fn new(args: &[String], root: Cow<'static, str>) -> Result<Config, Error> {
         let output_directory = match args.len() {
             2 | 4 => PathBuf::from(&args[1]),
             _ => return Err(failure::err_msg("This program requires 1 or 3 arguments")),
@@ -100,6 +112,7 @@ impl Config {
         let devices = Vec::new();
 
         let mut config = Config {
+            root,
             output_directory,
             devices,
         };
@@ -110,13 +123,13 @@ impl Config {
     }
 
     fn read(&mut self) -> Result<bool, Error> {
-        let path = Path::new("/etc/systemd/zram-generator.conf");
+        let path = Path::new(&self.root[..]).join("etc/systemd/zram-generator.conf");
         if !path.exists() {
             println!("No configuration file found.");
             return Ok(false);
         }
 
-        let conf = Ini::load_from_file(path).with_path(path)?;
+        let conf = Ini::load_from_file(&path).with_path(&path)?;
 
         let no_title = "(no title)".into();
         for (section_name, section) in conf.iter() {
@@ -160,11 +173,11 @@ fn handle_device(config: &Config, device: &Device, memtotal_mb: f64) -> Result<b
                  device.memory_limit_mb);
         return Ok(false);
     }
-    
+
     let disksize = (device.zram_fraction * memtotal_mb) as u64 * 1024 * 1024;
     let service_name = format!("swap-create@{}.service", device.name);
-    println!("Creating {} for /dev/{} ({}MB)",
-             service_name, device.name, disksize / 1024 / 1024);
+    println!("Creating {} for {}dev/{} ({}MB)",
+             service_name, config.root, device.name, disksize / 1024 / 1024);
     let device_name = format!("dev-{}.device", device.name);
 
     let service_path = config.output_directory.join(&service_name);
@@ -173,7 +186,7 @@ fn handle_device(config: &Config, device: &Device, memtotal_mb: f64) -> Result<b
 
     let contents = format!("\
 [Unit]
-Description=Create swap on /dev/%i
+Description=Create swap on {root}dev/%i
 Wants=systemd-modules-load.service
 After=systemd-modules-load.service
 After={device_name}
@@ -182,9 +195,10 @@ DefaultDependencies=false
 [Service]
 Type=oneshot
 ExecStartPre=-modprobe zram
-ExecStart=sh -c 'echo {disksize} >/sys/block/%i/disksize'
-ExecStart=mkswap /dev/%i
+ExecStart=sh -c 'echo {disksize} >{root}sys/block/%i/disksize'
+ExecStart=mkswap {root}dev/%i
 ",
+        root = config.root,
         device_name = device_name,
         disksize = disksize,
     );
@@ -198,13 +212,14 @@ ExecStart=mkswap /dev/%i
 
     let contents = format!("\
 [Unit]
-Description=Compressed swap on /dev/{zram_device}
+Description=Compressed swap on {root}dev/{zram_device}
 Requires={service}
 After={service}
 
 [Swap]
-What=/dev/{zram_device}
+What={root}dev/{zram_device}
 ",
+        root = config.root,
         service = service_name,
         zram_device = device.name
     );
@@ -218,7 +233,7 @@ What=/dev/{zram_device}
 }
 
 fn run(config: Config) -> Result<(), Error> {
-    let memtotal = get_total_memory()?;
+    let memtotal = get_total_memory(&config.root)?;
     let memtotal_mb = memtotal as f64 / 1024.;
 
     let mut some = false;
@@ -235,22 +250,21 @@ fn run(config: Config) -> Result<(), Error> {
 
     if some {
         /* We created some services, let's make sure the module is loaded */
-        let modules_load_path = "/run/modules-load.d/zram.conf";
-        let modules_load_path = Path::new(&modules_load_path);
+        let modules_load_path = Path::new(&config.root[..]).join("run/modules-load.d/zram.conf");
         let parent_path = modules_load_path.parent()
             .ok_or_else(|| format_err!("Couldn't get parent of {}", modules_load_path.display()))?;
         let _ = fs::create_dir_all(parent_path)?;
-        let mut modules_load = fs::File::create(modules_load_path).with_path(modules_load_path)?;
+        let mut modules_load = fs::File::create(&modules_load_path).with_path(&modules_load_path)?;
         modules_load.write(b"zram\n")?;
     }
 
     Ok(())
 }
 
-fn get_total_memory() -> Result<u64, Error> {
-    let path = Path::new("/proc/meminfo");
+fn get_total_memory(root: &str) -> Result<u64, Error> {
+    let path = Path::new(root).join("proc/meminfo");
 
-    let mut file = fs::File::open(&path).with_path(path)?;
+    let mut file = fs::File::open(&path).with_path(&path)?;
 
     let mut s = String::new();
     file.read_to_string(&mut s)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,11 @@ use std::borrow::Cow;
 use std::env;
 use std::fmt;
 use std::fs;
-use std::io::prelude::*;
+use std::io::{prelude::*, BufReader};
+use std::iter::FromIterator;
 use std::os::unix::fs::symlink;
 use std::path::{self, Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::result;
 
 pub trait ResultExt<T, E>: failure::ResultExt<T, E>
@@ -32,20 +33,24 @@ impl<T, E: fmt::Display> ResultExt<T, E> for result::Result<T, E> where
     result::Result<T, E>: failure::ResultExt<T, E>
 {}
 
+fn make_parent(of: &Path) -> Result<(), Error> {
+    let parent = of.parent()
+        .ok_or_else(|| format_err!("Couldn't get parent of {}", of.display()))?;
+    fs::create_dir_all(&parent)?;
+    Ok(())
+}
+
 fn make_symlink(dst: &str, src: &Path) -> Result<(), Error> {
-    let parent = src.parent()
-        .ok_or_else(|| format_err!("Couldn't get parent of {}", src.display()))?;
-    let _ = fs::create_dir_all(&parent);
+    make_parent(src)?;
     symlink(dst, src).with_path(src)?;
     Ok(())
 }
 
 fn virtualization_container() -> Result<bool, Error> {
-    let output = match Command::new("systemd-detect-virt").arg("--container").output() {
-        Ok(ok) => ok,
-        Err(e) => return Err(format_err!("systemd-detect-virt call failed: {}", e)),
-    };
-    return Ok(output.status.success());
+    match Command::new("systemd-detect-virt").arg("--container").stdout(Stdio::null()).status() {
+        Ok(status) => Ok(status.success()),
+        Err(e) => Err(format_err!("systemd-detect-virt call failed: {}", e)),
+    }
 }
 
 fn main() {
@@ -67,7 +72,7 @@ fn main() {
         },
     };
 
-    if config.devices.len() == 0 {
+    if config.devices.is_empty() {
         println!("No devices configured, exiting.");
         std::process::exit(0);
     }
@@ -96,9 +101,7 @@ impl Device {
 
 struct Config {
     root: Cow<'static, str>,
-
     output_directory: PathBuf,
-
     devices: Vec<Device>,
 }
 
@@ -109,59 +112,46 @@ impl Config {
             _ => return Err(failure::err_msg("This program requires 1 or 3 arguments")),
         };
 
-        let devices = Vec::new();
-
-        let mut config = Config {
-            root,
-            output_directory,
-            devices,
-        };
-
-        config.read()?;
-
-        Ok(config)
+        let devices = Config::read_devices(&root)?;
+        Ok(Config { root, output_directory, devices })
     }
 
-    fn read(&mut self) -> Result<bool, Error> {
-        let path = Path::new(&self.root[..]).join("etc/systemd/zram-generator.conf");
+    fn read_devices(root: &str) -> Result<Vec<Device>, Error> {
+        let path = Path::new(root).join("etc/systemd/zram-generator.conf");
         if !path.exists() {
             println!("No configuration file found.");
-            return Ok(false);
+            return Ok(vec![]);
         }
 
-        let conf = Ini::load_from_file(&path).with_path(&path)?;
-
-        let no_title = "(no title)".into();
-        for (section_name, section) in conf.iter() {
-            let section_name = section_name.as_ref().unwrap_or(&no_title);
+        Result::from_iter(Ini::load_from_file(&path).with_path(&path)?.into_iter().map(|(section_name, section)| {
+            let section_name = section_name.map(Cow::Owned).unwrap_or(Cow::Borrowed("(no title)"));
 
             if !section_name.starts_with("zram") {
                 println!("Ignoring section \"{}\"", section_name);
-                continue;
+                return Ok(None);
             }
 
-            let mut dev = Device::new(section_name.to_string());
+            let mut dev = Device::new(section_name.into_owned());
 
             if let Some(val) = section.get("memory-limit") {
                 if val == "none" {
                     dev.memory_limit_mb = u64::max_value();
                 } else {
                     dev.memory_limit_mb = val.parse()
-                        .map_err(|e| format_err!("Failed to parse memory-limit \"{}\":{}", val, e))?;
+                        .map_err(|e| format_err!("Failed to parse memory-limit \"{}\": {}", val, e))?;
                 }
             }
 
             if let Some(val) = section.get("zram-fraction") {
                 dev.zram_fraction = val.parse()
                     .map_err(|e| format_err!("Failed to parse zram-fraction \"{}\": {}", val, e))?;
-            };
+            }
 
             println!("Found configuration for {}: memory-limit={}MB zram-fraction={}",
                      dev.name, dev.memory_limit_mb, dev.zram_fraction);
-            self.devices.push(dev);
-        }
 
-        Ok(true)
+            Ok(Some(dev))
+        }).map(Result::transpose).flatten())
     }
 }
 
@@ -178,11 +168,8 @@ fn handle_device(config: &Config, device: &Device, memtotal_mb: f64) -> Result<b
     let service_name = format!("swap-create@{}.service", device.name);
     println!("Creating {} for {}dev/{} ({}MB)",
              service_name, config.root, device.name, disksize / 1024 / 1024);
-    let device_name = format!("dev-{}.device", device.name);
 
     let service_path = config.output_directory.join(&service_name);
-    let service_path = Path::new(&service_path);
-    let mut service = fs::File::create(service_path).with_path(service_path)?;
 
     let contents = format!("\
 [Unit]
@@ -199,16 +186,13 @@ ExecStart=sh -c 'echo {disksize} >{root}sys/block/%i/disksize'
 ExecStart=mkswap {root}dev/%i
 ",
         root = config.root,
-        device_name = device_name,
+        device_name = format!("dev-{}.device", device.name),
         disksize = disksize,
     );
-
-    service.write_all(&contents.into_bytes())?;
+    fs::write(&service_path, contents).with_path(service_path)?;
 
     let swap_name = format!("dev-{}.swap", device.name);
     let swap_path = config.output_directory.join(&swap_name);
-    let swap_path = Path::new(&swap_path);
-    let mut swap = fs::File::create(swap_path).with_path(swap_path)?;
 
     let contents = format!("\
 [Unit]
@@ -224,7 +208,7 @@ What={root}dev/{zram_device}
         zram_device = device.name
     );
 
-    swap.write_all(&contents.into_bytes())?;
+    fs::write(&swap_path, contents).with_path(swap_path)?;
 
     let symlink_path = config.output_directory.join("swap.target.wants").join(&swap_name);
     let target_path = format!("../{}", swap_name);
@@ -233,50 +217,39 @@ What={root}dev/{zram_device}
 }
 
 fn run(config: Config) -> Result<(), Error> {
-    let memtotal = get_total_memory(&config.root)?;
+    let memtotal = get_total_memory_kb(&config.root)?;
     let memtotal_mb = memtotal as f64 / 1024.;
-
-    let mut some = false;
 
     if virtualization_container()? {
         println!("Running in a container, exiting.");
         return Ok(());
     }
 
+    let mut devices_made = false;
     for dev in &config.devices {
-        let found = handle_device(&config, dev, memtotal_mb)?;
-        some |= found;
+        devices_made |= handle_device(&config, dev, memtotal_mb)?;
     }
-
-    if some {
+    if devices_made {
         /* We created some services, let's make sure the module is loaded */
         let modules_load_path = Path::new(&config.root[..]).join("run/modules-load.d/zram.conf");
-        let parent_path = modules_load_path.parent()
-            .ok_or_else(|| format_err!("Couldn't get parent of {}", modules_load_path.display()))?;
-        let _ = fs::create_dir_all(parent_path)?;
-        let mut modules_load = fs::File::create(&modules_load_path).with_path(&modules_load_path)?;
-        modules_load.write(b"zram\n")?;
+        make_parent(&modules_load_path)?;
+        fs::write(&modules_load_path, "zram\n").with_path(modules_load_path)?;
     }
 
     Ok(())
 }
 
-fn get_total_memory(root: &str) -> Result<u64, Error> {
+fn get_total_memory_kb(root: &str) -> Result<u64, Error> {
     let path = Path::new(root).join("proc/meminfo");
 
-    let mut file = fs::File::open(&path).with_path(&path)?;
-
-    let mut s = String::new();
-    file.read_to_string(&mut s)?;
-
-    for line in s.lines() {
-        let fields: Vec<_> = line.split_whitespace().collect();
-        if let (Some(k), Some(v)) = (fields.get(0), fields.get(1)) {
-            if *k == "MemTotal:" {
-                let memtotal: u64 = v.parse()?;
-                return Ok(memtotal);
-            };
-        };
+    for line in BufReader::new(fs::File::open(&path).with_path(&path)?).lines() {
+        let line = line?;
+        let mut fields = line.split_whitespace();
+        if let Some("MemTotal:") = fields.next() {
+            if let Some(v) = fields.next() {
+                return Ok(v.parse()?);
+            }
+        }
     }
 
     Err(format_err!("Couldn't find MemTotal in {}", path.display()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,7 @@ After={service}
 
 [Swap]
 What={root}dev/{zram_device}
+Options=pri=100
 ",
         root = config.root,
         service = service_name,


### PR DESCRIPTION
This PR implements:
  * `$ZRAM_GENERATOR_ROOT` from the TODO
  * priority setting on the generated swaps – I went with `100` like the zram-tools Debian package but that's easy be easy enough to change – closing #8 
  * code cleanliness, it's more idiomatic now
  * a fix to an error output format string