### PR TITLE
[ex-RFC] Use kernlog(/+simplelog) for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,8 @@ anyhow = "1.0.12"
 clap = { version = "2.33", default-features = false }
 liboverdrop = "0.0.2"
 rust-ini = ">=0.13, <0.16"
-kernlog = { git = "https://github.com/nabijaczleweli/kernlog.rs.git", rev = "a44a3f021815e091966741aa3bcdcefdfd51590d" }
-simplelog = { version = "0.8", default-features = false }
-log = "0.4"
+libc = "0.2"
+log = { version = "0.4", features = ["std"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ anyhow = "1.0.12"
 clap = { version = "2.33", default-features = false }
 liboverdrop = "0.0.2"
 rust-ini = ">=0.13, <0.16"
+kernlog = { git = "https://github.com/nabijaczleweli/kernlog.rs.git", rev = "a44a3f021815e091966741aa3bcdcefdfd51590d" }
+simplelog = { version = "0.8", default-features = false }
+log = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/TODO
+++ b/TODO
@@ -1,2 +1,1 @@
 - logging in generators needs to go to kmsg, println!() is not enough.
-- read configuration also from /usr/lib?

--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-- logging in generators needs to go to kmsg, println!() is not enough.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2,6 +2,7 @@
 
 use crate::config::Device;
 use anyhow::{anyhow, Context, Result};
+use log::{info, warn};
 use std::cmp;
 use std::fs;
 use std::iter::FromIterator;
@@ -32,7 +33,7 @@ fn virtualization_container() -> Result<bool> {
     {
         Ok(child) => child,
         Err(e) => {
-            eprintln!(
+            warn!(
                 "systemd-detect-virt call failed, assuming we're not in a container: {}",
                 e
             );
@@ -48,12 +49,12 @@ fn virtualization_container() -> Result<bool> {
 
 pub fn run_generator(devices: &[Device], output_directory: &Path, fake_mode: bool) -> Result<()> {
     if devices.is_empty() {
-        println!("No devices configured, exiting.");
+        info!("No devices configured, exiting.");
         return Ok(());
     }
 
     if virtualization_container()? && !fake_mode {
-        println!("Running in a container, exiting.");
+        info!("Running in a container, exiting.");
         return Ok(());
     }
 
@@ -91,7 +92,7 @@ pub fn run_generator(devices: &[Device], output_directory: &Path, fake_mode: boo
 
 fn handle_device(output_directory: &Path, device: &Device) -> Result<u64> {
     let swap_name = format!("dev-{}.swap", device.name);
-    println!(
+    info!(
         "Creating {} for /dev/{} ({}MB)",
         swap_name,
         device.name,

--- a/src/kernlog.rs
+++ b/src/kernlog.rs
@@ -1,0 +1,80 @@
+//! Logger implementation for low level kernel log (using `/dev/kmsg`)
+//!
+//! Borrowed and cut down from https://github.com/kstep/kernlog.rs/pull/2,
+//! consider merging changes back when fixing something here;
+//! this automatically falls back to stdout and ignores problems with opening "/dev/kmsg".
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::sync::Mutex;
+
+/// Kernel logger implementation
+pub struct KernelLog {
+    kmsg: Mutex<Option<File>>,
+    maxlevel: log::LevelFilter,
+}
+
+impl KernelLog {
+    /// Create new kernel logger with error level filter
+    pub fn with_level(level: log::LevelFilter) -> KernelLog {
+        KernelLog {
+            kmsg: Mutex::new(OpenOptions::new().write(true).open("/dev/kmsg").ok()),
+            maxlevel: level,
+        }
+    }
+}
+
+impl log::Log for KernelLog {
+    fn enabled(&self, meta: &log::Metadata) -> bool {
+        meta.level() <= self.maxlevel
+    }
+
+    fn log(&self, record: &log::Record) {
+        if record.level() > self.maxlevel {
+            return;
+        }
+
+        let level: u8 = match record.level() {
+            log::Level::Error => 3,
+            log::Level::Warn => 4,
+            log::Level::Info => 5,
+            log::Level::Debug => 6,
+            log::Level::Trace => 7,
+        };
+
+        let mut buf = Vec::new();
+        writeln!(
+            buf,
+            "<{}>{}[{}]: {}",
+            level,
+            record.target(),
+            unsafe { libc::getpid() },
+            record.args()
+        )
+        .unwrap();
+
+        if let Ok(mut kmsg) = self.kmsg.lock() {
+            match kmsg.as_mut() {
+                Some(kmsg) => {
+                    let _ = kmsg.write(&buf);
+                    let _ = kmsg.flush();
+                }
+                None => {
+                    let kmsg = io::stdout();
+                    let mut kmsg = kmsg.lock();
+                    let _ = kmsg.write(&buf);
+                    let _ = kmsg.flush();
+                }
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Setup kernel logger with specified error level as the default logger
+pub fn init_with_level(level: log::LevelFilter) -> Result<(), log::SetLoggerError> {
+    log::set_boxed_logger(Box::new(KernelLog::with_level(level)))?;
+    log::set_max_level(level);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@
 
 mod config;
 mod generator;
+mod kernlog;
 mod setup;
 
 use anyhow::Result;
 use clap::{app_from_crate, crate_authors, crate_description, crate_name, crate_version, Arg};
-use log::warn;
 use std::borrow::Cow;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -62,10 +62,7 @@ fn main() -> Result<()> {
     };
     let root = Path::new(&root[..]);
 
-    let _ = kernlog::init_with_level(log_level).or_else(|e| {
-        simplelog::SimpleLogger::init(simplelog::LevelFilter::max(), Default::default())
-            .map(|()| warn!("Couldn't initialise /dev/kmsg logger: {:?}", e))
-    });
+    let _ = kernlog::init_with_level(log_level);
 
     match get_opts() {
         Opts::GenerateUnits(target) => {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2,6 +2,7 @@
 
 use crate::config::Device;
 use anyhow::{anyhow, Context, Result};
+use log::warn;
 use std::fs;
 use std::io::ErrorKind;
 use std::os::unix::process::ExitStatusExt;
@@ -18,7 +19,7 @@ pub fn run_device_setup(device: Option<Device>, device_name: &str) -> Result<()>
         match fs::write(&comp_algorithm_path, &compression_algorithm) {
             Ok(_) => {}
             Err(err) if err.kind() == ErrorKind::InvalidInput => {
-                println!(
+                warn!(
                     "Warning: algorithm {:?} not recognised; consult {} for a list of available ones",
                     compression_algorithm, comp_algorithm_path.display(),
                 );


### PR DESCRIPTION
There's two ways of tying stdout/err to `/dev/kmsg` I've found so far:
1. [`gag`](https://docs.rs/gag/0.1.10/gag), which `dup2()`s an fd onto 1/2. The problem with that is /dev/kmsg's peculiar format, which'd have to be reproduced on each `println!()` call.
2. [`kernlog`](https://docs.rs/kernlog/0.2.1/kernlog/), which hooks onto the de-facto-standard `log` crate and manages that behind the scenes.

`kernlog` will, obviously, fail to initialise if it can't write to `/dev/kmsg` (usually this means it isn't root). This can be worked around in a few ways:
1. The maxi approach taken here, using another logger (here: `simplelog`, which is rather large dependency-wise), if kernlog doesn't initialise.
2. The midi approach, using, for example, a "develop" feature, which will enable `simplelog` only for builds you specify (I think one could be devilish and enable it only on the debug build profile, but).
3. The mini approach: simply not. If the logger initialises, great; if not: whatever. If no `log` logger is installed, the output is ignored.
4. The micro approach: `kernlog::init().unwrap()` or equivalent.

I've PRed `kernlog.rs` with an update from the 2015 state of affairs (https://github.com/kstep/kernlog.rs/pull/2), to no response so far; hence the `git=` dep.

![screenshot of two "zram-generator" invocations; first prefixed by sudo with output showing up in the journal, second without, with output showing up in the terminal](https://user-images.githubusercontent.com/6709544/84805138-16607780-b004-11ea-951e-1ed9ab43751f.png)

The `::module` thingies can be overriden with `warn!(target: "systemd-zram", ...)`, if desired