### PR TITLE
Bump min version of anyhow & bump version to 0.2.0-beta.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zram-generator"
-version = "0.1.2"
+version = "0.2.0-beta.1"
 authors = ["Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>"]
 license = "MIT"
 description = "Systemd unit generator for zram swap devices"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/systemd/zram-generator"
 edition = "2018"
 
 [dependencies]
-anyhow = "1"
+anyhow = "1.0.12"
 clap = { version = "2.33", default-features = false }
 liboverdrop = "0.0.2"
 rust-ini = ">=0.13, <0.16"


### PR DESCRIPTION
Even though tests are not working in some build environments (like Fedora), it would be still good to ship a new version ASAP so that people can test it.

We will fix the issue in release.