### PR TITLE
Use pkg-config for systemd directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,11 @@ jobs:
           override: true
           profile: minimal
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
+        run: make build CARGOFLAGS="--verbose"
       - name: Insert zram module
         run: sudo modprobe -v zram
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: make check CARGOFLAGS="--verbose"
 
   rustfmt:
     name: rustfmt

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 INSTALL = install
 CARGO = cargo
 RONN = ronn
+PKG_CONFIG = pkg-config
 PREFIX = /usr
 
-SYSTEMD_UTIL_DIR := $(shell pkg-config --variable=systemdutildir systemd)
-SYSTEMD_SYSTEM_UNIT_DIR := $(shell pkg-config --variable=systemdsystemunitdir systemd)
-SYSTEMD_SYSTEM_GENERATOR_DIR := $(shell pkg-config --variable=systemdsystemgeneratordir systemd)
+SYSTEMD_UTIL_DIR := $(shell $(PKG_CONFIG) --variable=systemdutildir systemd)
+SYSTEMD_SYSTEM_UNIT_DIR := $(shell $(PKG_CONFIG) --variable=systemdsystemunitdir systemd)
+SYSTEMD_SYSTEM_GENERATOR_DIR := $(shell $(PKG_CONFIG) --variable=systemdsystemgeneratordir systemd)
 
 SYSTEMD_MAKEFS_COMMAND = $(SYSTEMD_UTIL_DIR)/systemd-makefs
 export SYSTEMD_MAKEFS_COMMAND

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,7 @@ PREFIX = /usr
 SYSTEMD_UTIL_DIR := $(shell $(PKG_CONFIG) --variable=systemdutildir systemd)
 SYSTEMD_SYSTEM_UNIT_DIR := $(shell $(PKG_CONFIG) --variable=systemdsystemunitdir systemd)
 SYSTEMD_SYSTEM_GENERATOR_DIR := $(shell $(PKG_CONFIG) --variable=systemdsystemgeneratordir systemd)
-
-SYSTEMD_MAKEFS_COMMAND = $(SYSTEMD_UTIL_DIR)/systemd-makefs
-export SYSTEMD_MAKEFS_COMMAND
+export SYSTEMD_UTIL_DIR
 
 .DEFAULT: build
 .PHONY: build man check clean install

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 INSTALL = install
 CARGO = cargo
+CARGOFLAGS =
 RONN = ronn
 PKG_CONFIG = pkg-config
 PREFIX = /usr
@@ -13,7 +14,7 @@ export SYSTEMD_UTIL_DIR
 .PHONY: build man check clean install
 
 build:
-	@$(CARGO) build --release
+	@$(CARGO) build --release $(CARGOFLAGS)
 	@sed -e 's,@SYSTEMD_SYSTEM_GENERATOR_DIR@,$(SYSTEMD_SYSTEM_GENERATOR_DIR),' \
 		< units/swap-create@.service.in \
 		> units/swap-create@.service
@@ -22,7 +23,7 @@ man:
 	@$(RONN) --organization="zram-generator developers" man/*.md
 
 check: build
-	@$(CARGO) test --release
+	@$(CARGO) test --release $(CARGOFLAGS)
 
 clean:
 	@$(CARGO) clean

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ systemd generator in rust. Details are still being figured out.
 ### Installation
 
 Executing `make install` will create the following things:
-* Generator binary installed as `/usr/lib/systemd/system-generators/zram-generator`
+* `zram-generator` binary installed in the systemd system generator directory (usually `/usr/lib/systemd/system-generators/`)
 * `zram-generator(8)` and `zram-generator.conf(5)` manpages installed into `/usr/share/man/manN/`, this requires [`ronn`](https://github.com/apjanke/ronn-ng).
-* `units/swap-create@.service` copied into `/usr/lib/systemd/system/`
+* `units/swap-create@.service` copied into the systemd system unit directory (usually `/usr/lib/systemd/system/`)
 * `zram-generator.conf.example` copied into `/usr/share/doc/zram-generator/`
 You need though create your own config file at one of the locations listed above.
 

--- a/units/swap-create@.service.in
+++ b/units/swap-create@.service.in
@@ -10,5 +10,5 @@ DefaultDependencies=false
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/lib/systemd/system-generators/zram-generator --setup-device '%i'
-ExecStop=/usr/lib/systemd/system-generators/zram-generator --reset-device '%i'
+ExecStart=@SYSTEMD_SYSTEM_GENERATOR_DIR@/zram-generator --setup-device '%i'
+ExecStop=@SYSTEMD_SYSTEM_GENERATOR_DIR@/zram-generator --reset-device '%i'


### PR DESCRIPTION
This is a fix for the installation problems on Debain, #40. (Or not just Debian, probably all non-merged-/usr distributions are affected?)

----

Add pkg-config calls to the Makefile.

Use an environment variable to pass the location of systemd-makefs to
the Rust code. This gets evaluated at compile-time. If the env var is
unset (e.g. when cargo is invoked by hand), a default is used.

The unit file also needs to be edited before installation.