### PR TITLE
make: split systemd_service target out of build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Cargo.lock
 /target
 **/*.rs.bk
+/units/*.service

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ export SYSTEMD_UTIL_DIR
 .DEFAULT: build
 .PHONY: build man check clean install
 
-build:
+build: systemd_service
 	@$(CARGO) build --release $(CARGOFLAGS)
+
+systemd_service:
 	@sed -e 's,@SYSTEMD_SYSTEM_GENERATOR_DIR@,$(SYSTEMD_SYSTEM_GENERATOR_DIR),' \
 		< units/swap-create@.service.in \
 		> units/swap-create@.service


### PR DESCRIPTION
And also add generated unit to gitignore

Handy for packaging, when the cargo stuff is already handled outside of the Makefile