### PR TITLE
Replace libc::getpid with std::process::id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0.12"
 clap = { version = "2.33", default-features = false }
 liboverdrop = "0.0.2"
 rust-ini = ">=0.13, <0.16"
-libc = "0.2"
 log = { version = "0.4", features = ["std"] }
 
 [dev-dependencies]

--- a/src/kernlog.rs
+++ b/src/kernlog.rs
@@ -6,6 +6,7 @@
 
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
+use std::process::id;
 use std::sync::Mutex;
 
 /// Kernel logger implementation
@@ -39,7 +40,7 @@ fn _write_kmsg(kmsg: &mut File, record: &log::Record) {
         "<{}>{}[{}]: {}",
         level,
         record.target(),
-        unsafe { libc::getpid() },
+        id(),
         record.args()
     )
     .unwrap();


### PR DESCRIPTION
`std::process::id()` was added in rust 1.26.

I'm a bit unsure on the formatting, is it preferable to `use std::process` and then `process::id()` or is that wrong cause it imports unnecessary code into the namespace?