### PR TITLE
fix: Install from source split out `build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It is recommended to use an existing package:
 * Arch: AUR packages https://aur.archlinux.org/packages/zram-generator/ (or
         https://aur.archlinux.org/packages/zram-generator-git/ for the latest git commit)
 
-To install directly from sources, execute `make install`:
+To install directly from sources, execute `make build && make install`:
 * `zram-generator` binary is installed in the systemd system generator directory (usually `/usr/lib/systemd/system-generators/`)
 * `zram-generator(8)` and `zram-generator.conf(5)` manpages are installed into `/usr/share/man/manN/`, this requires [`ronn`](https://github.com/apjanke/ronn-ng).
 * `units/systemd-zram-setup@.service` is copied into the systemd system unit directory (usually `/usr/lib/systemd/system/`)


### PR DESCRIPTION
Recent change modified the `Makefile`, but did not perform a clean build test which would show failure from `make install` advice in the README instructions to build from source. `make build` is also required now.

```
$ make install
# install -Dpm755 target/release/zram-generator -t /usr/lib/systemd/system-generators/
# install: cannot stat 'target/release/zram-generator': No such file or directory
# make: *** [Makefile:35: install] Error 1
```