### PR TITLE
allow building against rust-ini 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 anyhow = "1.0.12"
 clap = { version = "2.33", default-features = false }
 liboverdrop = "0.0.2"
-rust-ini = ">=0.13, <0.17"
+rust-ini = ">=0.13, <0.18"
 log = { version = "0.4", features = ["std"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Already merged downstream in Fedora. Does not require code changes (no relevant API changes between 0.16 and 0.17).