### PR TITLE
man: fix template name

### DIFF
--- a/man/zram-generator.md
+++ b/man/zram-generator.md
@@ -29,14 +29,14 @@ Setting the `ZRAM_GENERATOR_ROOT` environment variable makes the generator run i
 For the ramifications of `ZRAM_GENERATOR_ROOT` on config handling, see zram-generator.conf(5).
 
 
-Generated *dev-zramN.swap* units depend on `systemd-swap-create@zramN.service`, which will:
+Generated *dev-zramN.swap* units depend on `systemd-zram-setup@zramN.service`, which will:
 
   1. read configuration files from *{/etc,/lib}/systemd/zram-generator.conf[.d]* (see zram-generator.conf(5) for details);
   2. set the desired compression algorithm, if any;
      if the current kernel doesn't understand the specified algorithm, a warning is issued, but execution continues;
   3. set the desired blockdev size and format it as swap with *systemd-makefs(8)*.
 
-Generated *path-to-mount-point.mount* units depend on `systemd-swap-create@zramN.service`.
+Generated *path-to-mount-point.mount* units depend on `systemd-zram-setup@zramN.service`.
 The effect is similar to what happens for swap units, but of course they are formatted with a file system.
 
 When the unit is stopped, the zram device is reset, freeing memory and allowing the device to be reused.


### PR DESCRIPTION
I missed those somehow in 5502a7ecd90f2fb68f710ca06a7a1ad56cb4590c.
Fixes #80.