### PR TITLE
make: rework targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           override: true
           profile: minimal
       - name: Build
-        run: make build CARGOFLAGS="--verbose"
+        run: make program CARGOFLAGS="--verbose"
       - name: Run tests
         run: make check CARGOFLAGS="--verbose"
 


### PR DESCRIPTION
'make && make install' did not work because the man page wasn't listed
in dependencies. Let's redo the whole scheme:
'make build' builds everything,
'make program', 'make man', 'make systemd-service' build each of
the three items, and 'make install' should now always work.

"systemd_service" is renamed to "systemd-service". Dashes are normally
used in Makefile target names, no need to bother with underscores.

Fixes #82.