### PR TITLE
Rework Installation Related

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Install linux-modules-extra-azure
+        run: |
+          sudo apt update
+          sudo apt install -y linux-modules-extra-azure
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -30,11 +34,11 @@ jobs:
           override: true
           profile: minimal
       - name: Build
-        run: make build CARGOFLAGS="--verbose"
+        run: CARGOFLAGS="--verbose" make build
       - name: Insert zram module
         run: sudo modprobe -v zram
       - name: Run tests
-        run: make check CARGOFLAGS="--verbose"
+        run: CARGOFLAGS="--verbose" make test
 
   rustfmt:
     name: rustfmt

--- a/Makefile
+++ b/Makefile
@@ -12,30 +12,36 @@ SYSTEMD_SYSTEM_UNIT_DIR := $(shell $(PKG_CONFIG) --variable=systemdsystemunitdir
 SYSTEMD_SYSTEM_GENERATOR_DIR := $(shell $(PKG_CONFIG) --variable=systemdsystemgeneratordir systemd)
 export SYSTEMD_UTIL_DIR
 
-.DEFAULT: build
-.PHONY: build man check clean install
+all: build man
 
-build: systemd_service
+.PHONY: build
+build:
 	@$(CARGO) build --release $(CARGOFLAGS)
-
-systemd_service:
 	@sed -e 's,@SYSTEMD_SYSTEM_GENERATOR_DIR@,$(SYSTEMD_SYSTEM_GENERATOR_DIR),' \
 		< units/systemd-zram-setup@.service.in \
 		> units/systemd-zram-setup@.service
 
+.PHONY: man
 man:
 	@$(RONN) --organization="zram-generator developers" man/*.md
 
-check: build
+.PHONY: test
+test:
 	@$(CARGO) test --release $(CARGOFLAGS)
 
-clean:
-	@$(CARGO) clean
-	@rm -f units/systemd-zram-setup@.service
+.PHONY: install
+install: install.bin install.man
 
-install:
+install.bin:
 	$(INSTALL) -Dpm755 target/release/zram-generator -t $(DESTDIR)$(SYSTEMD_SYSTEM_GENERATOR_DIR)/
 	$(INSTALL) -Dpm644 units/systemd-zram-setup@.service -t $(DESTDIR)$(SYSTEMD_SYSTEM_UNIT_DIR)/
 	$(INSTALL) -Dpm644 zram-generator.conf.example -t $(DESTDIR)$(PREFIX)/share/doc/zram-generator/
+
+install.man:
 	$(INSTALL) -Dpm644 man/zram-generator.8 -t $(DESTDIR)$(PREFIX)/share/man/man8/
 	$(INSTALL) -Dpm644 man/zram-generator.conf.5 -t $(DESTDIR)$(PREFIX)/share/man/man5/
+
+.PHONY: clean
+clean:
+	@$(CARGO) clean
+	@rm -f units/systemd-zram-setup@.service

--- a/README.md
+++ b/README.md
@@ -1,89 +1,167 @@
 # `systemd-zram-setup@.service` generator for zram devices
 
-This generator provides a simple and fast mechanism to configure swap on `/dev/zram*` devices.
+This generator provides a simple and fast mechanism to configure swap on
+`/dev/zram*` devices.
 
-The main use case is create **swap** devices, but devices with a file system can be created too, see below.
+The main use case is create **swap** devices, but devices with a file
+system can be created too, see below.
 
-### Configuration
+## Configuration
 
-A default config file may be located in /usr.
-This generator checks the following locations:
-* `/run/systemd/zram-generator.conf`
-* `/etc/systemd/zram-generator.conf`
-* `/usr/local/lib/systemd/zram-generator.conf`
-* `/usr/lib/systemd/zram-generator.conf`
+A default config file may be located in /usr. This generator checks the
+following locations:
 
-… and the first file found in that list wins.
+  - `/run/systemd/zram-generator.conf`
+  - `/etc/systemd/zram-generator.conf`
+  - `/usr/local/lib/systemd/zram-generator.conf`
+  - `/usr/lib/systemd/zram-generator.conf`
+
+... and the first file found in that list wins.
 
 In addition, "drop-ins" will be loaded from `.conf` files in
 `/etc/systemd/zram-generator.conf.d/`,
 `/usr/lib/systemd/zram-generator.conf.d/`, etc.
 
 The main configuration file is read before any of the drop-ins and has
-the lowest precedence; entries in the drop-in files override entries
-in the main configuration file.
+the lowest precedence; entries in the drop-in files override entries in
+the main configuration file.
 
 See systemd.unit(5) for a detailed description of this logic.
 
 See `zram-generator.conf.example` for a list of available settings.
 
-### Swap devices
+## Swap devices
 
 Create `/etc/systemd/zram-generator.conf`:
 
-```ini
-# /etc/systemd/zram-generator.conf
-[zram0]
-zram-fraction = 0.5
-```
+    # /etc/systemd/zram-generator.conf
+    [zram0]
+    zram-fraction = 0.5
 
-A zram device will be created for each section. No actual
-configuration is necessary (the default of `zram-fraction=0.5` will be
-used unless overriden), but the configuration file with at least one
-section must exist.
+A zram device will be created for each section. No actual configuration
+is necessary (the default of `zram-fraction=0.5` will be used unless
+overriden), but the configuration file with at least one section must
+exist.
 
-### Mount points
+## Mount points
 
-```ini
-# /etc/systemd/zram-generator.conf
-[zram1]
-mount-point = /var/tmp
-```
+    # /etc/systemd/zram-generator.conf
+    [zram1]
+    mount-point = /var/tmp
 
-This will set up a /dev/zram1 with ext2 and generate a mount unit for /var/tmp.
+This will set up a /dev/zram1 with ext2 and generate a mount unit for
+/var/tmp.
 
-### Rust
+## Rust
 
 The second purpose of this program is to serve as an example of a
 systemd generator in rust. Details are still being figured out.
 
-### Installation
+## Installation
+
+### Package Manager
 
 It is recommended to use an existing package:
 
-* Fedora: `sudo dnf install zram-generator-defaults` (or `sudo dnf install zram-generator` to install without the default configuration)
-* Debian: packages provided by nabijaczleweli, see https://debian.nabijaczleweli.xyz/README.
-* Arch: `sudo pacman -S zram-generator` (or https://aur.archlinux.org/packages/zram-generator-git/ for the latest git commit)
+#### Fedora 33+
 
-To install directly from sources, execute `make build && sudo make install`:
-* `zram-generator` binary is installed in the systemd system generator directory (usually `/usr/lib/systemd/system-generators/`)
-* `zram-generator(8)` and `zram-generator.conf(5)` manpages are installed into `/usr/share/man/manN/`, this requires [`ronn`](https://github.com/apjanke/ronn-ng).
-* `units/systemd-zram-setup@.service` is copied into the systemd system unit directory (usually `/usr/lib/systemd/system/`)
-* `zram-generator.conf.example` is copied into `/usr/share/doc/zram-generator/`
-You need though create your own config file at one of the locations listed above.
+    sudo yum install -y zram-generator
 
-### Testing
+#### Debian 11+ / Ubuntu 20.04+
 
-The tests require either the `zram` module to be loaded, or root to run `modprobe zram`.
+    curl -skL https://keybase.io/nabijaczleweli/pgp_keys.asc | sudo apt-key add
+    sudo apt-add-repository "deb https://debian.nabijaczleweli.xyz stable main"
+    sudo apt install -y systemd-zram
 
-Set the `ZRAM_GENERATOR_ROOT` environment variable to use that
-instead of `/` as root.
+#### Arch
 
-The "{generator}" template in `units/systemd-zram-setup@.service.d/binary-location.conf`
-can be substituted for a non-standard location of the binary for testing.
+    sudo pacman -S zram-generator
 
-### Authors
+### Source
 
-Written by Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>,
-Igor Raits <i.gnatenko.brain@gmail.com>, наб <nabijaczleweli@gmail.com>, and others.
-See https://github.com/systemd/zram-generator/graphs/contributors for the full list.
+#### Fedora 33+ / CentOS 8+ / RHEL 8+
+
+    sudo yum install -y cargo pkgconfig ruby-devel
+    sudo gem install ronn-ng
+
+#### Debian 10+ / Ubuntu 18.04+
+
+    sudo apt update
+    sudo apt install -y cargo pkg-config ruby-dev
+    sudo gem install ronn-ng
+
+#### openSUSE Leap 15.3+ / Tumbleweed
+
+    sudo zypper install -y cargo pkgconfig ruby-devel
+    sudo gem install ronn-ng
+    sudo ln -s /usr/bin/ronn.* /usr/bin/ronn
+
+#### Build and Install
+
+Get the latest source code with:
+
+    git clone https://github.com/systemd/zram-generator.git
+    cd zram-generator
+
+To install directly from sources, execute:
+
+    make
+    make test
+    sudo make install
+
+Which:
+
+  - `zram-generator` binary is installed in the systemd system generator
+    directory (usually `/usr/lib/systemd/system-generators/`)
+  - `zram-generator(8)` and `zram-generator.conf(5)` manpages are
+    installed into `/usr/share/man/manN/`, this requires
+    [`ronn`](https://github.com/apjanke/ronn-ng).
+  - `units/systemd-zram-setup@.service` is copied into the systemd
+    system unit directory (usually `/usr/lib/systemd/system/`)
+  - `zram-generator.conf.example` is copied into
+    `/usr/share/doc/zram-generator/` You need though create your own
+    config file at one of the locations listed above.
+
+Ensure required kernel module load during system start:
+
+    cat > /usr/lib/modules-load.d/zram-generator.conf <<-EOF
+    zram
+    EOF
+    systemctl restart systemd-modules-load.service
+
+Configure `zram0`, restart service and config zram device created:
+
+    cat > /etc/systemd/zram-generator.conf <<-EOF
+    [zram0]
+    host-memory-limit = none
+    max-zram-size = none
+    zram-fraction = 1.0
+    EOF
+    systemctl restart systemd-zram-setup@zram0.service
+    zramctl
+
+After reboot your zram swap will be enabled automatically.
+
+## Testing
+
+The tests require either the `zram` module to be loaded, or root to run
+`modprobe zram`.
+
+Set the `ZRAM_GENERATOR_ROOT` environment variable to use that instead
+of `/` as root.
+
+The "{generator}" template in
+`units/systemd-zram-setup@.service.d/binary-location.conf` can be
+substituted for a non-standard location of the binary for testing.
+
+## Authors
+
+Written by:
+
+  - Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
+  - Igor Raits <i.gnatenko.brain@gmail.com>
+  - наб <nabijaczleweli@gmail.com>
+  - and others.
+
+See <https://github.com/systemd/zram-generator/graphs/contributors> for
+the full list.


### PR DESCRIPTION
  - Rewrite `Makefile` so we could manage it with `make && make test && sudo make install`
  - Split `make man` and `make install.man`, therefore could simply skip when packaging with RPM/DEB/etc
  - Improve `README.md` with installation and testing procedure
  - Re-format `README.md` with `pandoc -f gfm -t gfm -o README.md README.md`

Fixes #82
Fixes #83

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>