### PR TITLE
rpm: Add Sample for RPM Packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Install linux-modules-extra-$(uname -r)
+        run: |
+          sudo apt update
+          sudo apt install -y linux-modules-extra-$(uname -r)
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
           override: true
           profile: minimal
-      - name: Build
-        run: make build CARGOFLAGS="--verbose"
       - name: Insert zram module
         run: sudo modprobe -v zram
+      - name: Build
+        run: make bin CARGOFLAGS="--verbose"
       - name: Run tests
-        run: make check CARGOFLAGS="--verbose"
+        run: make test CARGOFLAGS="--verbose"
 
   rustfmt:
     name: rustfmt

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+**/*.rs.bk
 *~
+/.cargo/config.toml
 /Cargo.lock
 /target
-**/*.rs.bk
+/vendor

--- a/Makefile
+++ b/Makefile
@@ -10,32 +10,54 @@ PREFIX = /usr
 SYSTEMD_UTIL_DIR := $(shell $(PKG_CONFIG) --variable=systemdutildir systemd)
 SYSTEMD_SYSTEM_UNIT_DIR := $(shell $(PKG_CONFIG) --variable=systemdsystemunitdir systemd)
 SYSTEMD_SYSTEM_GENERATOR_DIR := $(shell $(PKG_CONFIG) --variable=systemdsystemgeneratordir systemd)
+
 export SYSTEMD_UTIL_DIR
+export SYSTEMD_SYSTEM_UNIT_DIR
+export SYSTEMD_SYSTEM_GENERATOR_DIR
 
-.DEFAULT: build
-.PHONY: build man check clean install
+.PHONY: all
+all: bin systemd man
 
-build: systemd_service
+.PHONY: vendor
+vendor:
+	@mkdir -p .cargo
+	@$(CARGO) vendor > .cargo/config.toml
+
+.PHONY: bin
+bin:
 	@$(CARGO) build --release $(CARGOFLAGS)
 
-systemd_service:
+.PHONY: systemd
+systemd:
 	@sed -e 's,@SYSTEMD_SYSTEM_GENERATOR_DIR@,$(SYSTEMD_SYSTEM_GENERATOR_DIR),' \
 		< units/systemd-zram-setup@.service.in \
 		> units/systemd-zram-setup@.service
 
+.PHONY: man
 man:
 	@$(RONN) --organization="zram-generator developers" man/*.md
 
-check: build
+.PHONY: test
+test:
 	@$(CARGO) test --release $(CARGOFLAGS)
 
+.PHONY: install
+install: install.bin install.conf install.systemd install.man
+
+install.bin:
+	$(INSTALL) -Dpm755 target/release/zram-generator -t $(DESTDIR)$(SYSTEMD_SYSTEM_GENERATOR_DIR)/
+
+install.conf:
+	$(INSTALL) -Dpm644 zram-generator.conf.example -t $(DESTDIR)$(PREFIX)/share/doc/zram-generator/
+
+install.systemd:
+	$(INSTALL) -Dpm644 units/systemd-zram-setup@.service -t $(DESTDIR)$(SYSTEMD_SYSTEM_UNIT_DIR)/
+
+install.man:
+	$(INSTALL) -Dpm644 man/zram-generator.8 -t $(DESTDIR)$(PREFIX)/share/man/man8/
+	$(INSTALL) -Dpm644 man/zram-generator.conf.5 -t $(DESTDIR)$(PREFIX)/share/man/man5/
+
+.PHONY: clean
 clean:
 	@$(CARGO) clean
 	@rm -f units/systemd-zram-setup@.service
-
-install:
-	$(INSTALL) -Dpm755 target/release/zram-generator -t $(DESTDIR)$(SYSTEMD_SYSTEM_GENERATOR_DIR)/
-	$(INSTALL) -Dpm644 units/systemd-zram-setup@.service -t $(DESTDIR)$(SYSTEMD_SYSTEM_UNIT_DIR)/
-	$(INSTALL) -Dpm644 zram-generator.conf.example -t $(DESTDIR)$(PREFIX)/share/doc/zram-generator/
-	$(INSTALL) -Dpm644 man/zram-generator.8 -t $(DESTDIR)$(PREFIX)/share/man/man8/
-	$(INSTALL) -Dpm644 man/zram-generator.conf.5 -t $(DESTDIR)$(PREFIX)/share/man/man5/

--- a/rpm/zram-generator.conf
+++ b/rpm/zram-generator.conf
@@ -1,0 +1,9 @@
+# This config file enables a /dev/zram0 device with the default settings:
+# — size — same as available RAM or 8GB, whichever is less
+# — compression — most likely lzo-rle
+#
+# To disable, uninstall zram-generator-defaults or create empty
+# /etc/systemd/zram-generator.conf file.
+[zram0]
+zram-fraction = 1.0
+max-zram-size = 8192

--- a/rpm/zram-generator.spec
+++ b/rpm/zram-generator.spec
@@ -1,0 +1,61 @@
+%global debug_package %{nil}
+
+%if 0%{?centos_version} == 700 || 0%{?centos_version} == 800
+%global _systemd_util_dir %{_prefix}/lib/systemd
+%endif
+
+Name: zram-generator
+Version: 0.3.2+git20210726
+Release: 1%{?dist}
+Summary: Systemd unit generator for zram swap devices
+License: MIT
+URL: https://github.com/systemd/zram-generator
+Source0: %{name}_%{version}.orig.tar.gz
+BuildRequires: cargo
+
+%description
+This is a systemd unit generator that enables swap on zram.
+(With zram, there is no physical swap device. Part of the avaialable RAM
+is used to store compressed pages, essentially trading CPU cycles for memory.)
+To activate, install zram-generator-defaults subpackage.
+
+%files
+%license LICENSE
+%doc zram-generator.conf.example
+%doc README.md
+%{_systemdgeneratordir}
+%{_systemdgeneratordir}/zram-generator
+%{_unitdir}/systemd-zram-setup@.service
+
+%package -n zram-generator-defaults
+Summary: Default configuration for zram-generator
+Requires: zram-generator = %{version}-%{release}
+Obsoletes: zram < 0.4-2
+BuildArch: noarch
+
+%description -n zram-generator-defaults
+%{summary}.
+
+%files -n zram-generator-defaults
+%{_prefix}/lib/systemd/zram-generator.conf
+
+%prep
+%autosetup -T -c -n zram-generator_%{version}-%{release}
+tar -zx -f %{S:0} --strip-components=1 -C .
+
+%build
+make bin systemd SYSTEMD_UTIL_DIR=%{_systemd_util_dir} SYSTEMD_SYSTEM_UNIT_DIR=%{_unitdir} SYSTEMD_SYSTEM_GENERATOR_DIR=%{_systemdgeneratordir}
+
+%install
+make install.bin install.systemd SYSTEMD_UTIL_DIR=%{_systemd_util_dir} SYSTEMD_SYSTEM_UNIT_DIR=%{_unitdir} SYSTEMD_SYSTEM_GENERATOR_DIR=%{_systemdgeneratordir} DESTDIR=%{buildroot}
+install -Dpm0644 rpm/zram-generator.conf -t %{buildroot}%{_prefix}/lib/systemd/
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%changelog
+* Thu Jul 26 2021 Wong Hoi Sing Edison <hswong3i@gmail.com> - 0.3.2+git20210726-1
+- Initial release.
+- Split package into `zram-generator` and `zram-generator-defaults`.
+- Clone default configuration from https://src.fedoraproject.org/rpms/rust-zram-generator/blob/rawhide/f/zram-generator.conf
+- Add `mount-options` support


### PR DESCRIPTION
These files are now used by <https://build.opensuse.org/package/show/home:alvistack/zram-generator> for RPM packaging, tested with:

  - Fedora 33, 34
  - CentOS 8
  - openSUSE Leap 15.3, Tumbleweed

For testing:

  - Setup build directory with `rpmdev-setuptree`
  - Run `make vendor` inside source code directory
  - Update the `Version` and `Release` from `rpm/zram-generator.spec`
  - Copy and rename `rpm/zram-generator.spec`, e.g. `~/rpmbuild/SPECS/zram-generator_0.3.2+main-7.spec`
  - Compress the entire source code directory with `tar zcvf`, e.g. `~/rpmbuild/SOURCES/zram-generator_0.3.2+main.orig.tar.gz`
  - Build the RPM with `rpmbuild -bb ~/rpmbuild/SPECS/zram-generator_0.3.2+main-7.spec`
  - Install the result RPM with `rpm -ivh ~/rpmbuild/RPMS/zram-generator_0.3.2+main-7.rpm`

P.S. It share the same upstream filename name `Source0:
%{name}_%{version}.orig.tar.gz` as DEB packaging requirement.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>