### PR TITLE
Cargo.toml: lto = "thin"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ tempfile = "3"
 fs_extra = "1.1"
 
 [profile.release]
-lto = true
+lto = "thin"


### PR DESCRIPTION
Refer to <https://github.com/nabijaczleweli/systemd-zram-generator.deb/commit/8f2f3faf7f1334cfa5ba29352bacada25beeba5a>, building package on Debian 10+ and Ubuntu 20.04+ will fail with `lto = true`.

Moreover, tested with <https://build.opensuse.org/package/show/home:alvistack:systemd/zram-generator>, `lto = "thin"` working well for all support OS, including CentOS/Fedora/Debian/Ubuntu/openSUSE.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>