### PR TITLE
generator: drop quotes in Where=

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -284,10 +284,10 @@ After=systemd-zram-setup@{zram_device}.service
 
 [Mount]
 What=/dev/{zram_device}
-Where={mount_point:?}
+Where={mount_point}
 ",
             zram_device = device.name,
-            mount_point = device.mount_point.as_ref().unwrap(),
+            mount_point = device.mount_point.as_ref().unwrap().to_str().unwrap(),
         ),
     )?;
 

--- a/tests/07-mount-point/run.expected/units/var-compressed.mount
+++ b/tests/07-mount-point/run.expected/units/var-compressed.mount
@@ -8,4 +8,4 @@ After=systemd-zram-setup@zram11.service
 
 [Mount]
 What=/dev/zram11
-Where="/var/compressed"
+Where=/var/compressed


### PR DESCRIPTION
> /run/systemd/generator/var-tmp.mount:11: Where= path is not absolute, ignoring: "/var/tmp"

I think this is should also be fixed in systemd: it should unquote
Where=. But even if that is changed there, we still need to support current
systemd, so also need to fix it here.

Fixes #75.