### PR TITLE
Mount filesystems with "discard" option by default

### DIFF
--- a/man/zram-generator.conf.md
+++ b/man/zram-generator.conf.md
@@ -102,6 +102,8 @@ Devices with the final size of *0* will be discarded.
 
   Note that the device is temporary: contents will be destroyed automatically after the file system is unmounted (to release the backing memory).
 
+  The chosen file system must support the `discard` option.
+
   Also see systemd-makefs(8).
 
 ## ENVIRONMENT VARIABLES

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -285,6 +285,7 @@ After=systemd-zram-setup@{zram_device}.service
 [Mount]
 What=/dev/{zram_device}
 Where={mount_point}
+Options=discard
 ",
             zram_device = device.name,
             mount_point = device.mount_point.as_ref().unwrap().to_str().unwrap(),

--- a/tests/07-mount-point/run.expected/units/var-compressed.mount
+++ b/tests/07-mount-point/run.expected/units/var-compressed.mount
@@ -9,3 +9,4 @@ After=systemd-zram-setup@zram11.service
 [Mount]
 What=/dev/zram11
 Where=/var/compressed
+Options=discard


### PR DESCRIPTION
As discussed in https://github.com/systemd/zram-generator/pull/95, when files
are removed from the filesystem, without "discard", the blocks remain allocated
and consume memory. With the option, they are freed. So mounting without discard
doesn't make much sense.

ext2 (which is now backed by the ext4 code) supports "discard", even though the
documentation doesn't say this. It is possible that some other fs types don't
support discard, but all the recent ones do. And even if there *is* a filesystem
that doesn't do discard, and somebody is using our zram devices with it, it's
probably better if the mount fails than using the fs without discard. So even
though this is a small compatibility break, I don't expect this to be a problem
in practice.

I tested this with ext2, and it's clear that the blocks don't get deallocated
when files are removed. With swap, it seems that the discarding happens even
without the option, and none of the docs I could see mention "discard" for swap.
It seems we don't need to do the same for swap.