### PR TITLE
Optimize for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ fs_extra = "1.1"
 
 [profile.release]
 lto = "thin"
-opt-level = "z"  # Optimize for size.
+opt-level = "z"
 codegen-units = 1


### PR DESCRIPTION
zram-generator does very particular small job, it does not perform any heavy computation. It worth optimizing for size. In my tests this saves about 150KB of compiled binary.

Based on advices from https://github.com/johnthagen/min-sized-rust . Something else from this manual might be useful as well.