### PR TITLE
Panic on abort to optimize for size a bit more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ fs_extra = "1.1"
 lto = "thin"
 opt-level = "z"
 codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
```
$ ls -l target/release/zram-generator*
-rwxr-xr-x 2 zbyszek zbyszek 5531440 Oct 27 10:45 target/release/zram-generator.orig.unstripped
-rwxr-xr-x 2 zbyszek zbyszek 5220552 Oct 27 10:49 target/release/zram-generator.unstripped
-rwxr-xr-x 2 zbyszek zbyszek 936480 Oct 27 10:52 target/release/zram-generator.orig
-rwxr-xr-x 2 zbyszek zbyszek 858568 Oct 27 10:52 target/release/zram-generator
```

In our case the backtrace is almost always completely uninteresting:
generally the errors we encounter are from interaction with the
system, and not from internal state. By removing the backtraces we save
another 8% on size.