### PR TITLE
Only print diff(1) output if not empty

### DIFF
--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -58,8 +58,11 @@ fn test_generation(path: &str) -> Result<Vec<config::Device>> {
         .arg(srcroot.join("run.expected"))
         .arg(root.join("run"))
         .output()?;
-    println!("stdout:\n{}", String::from_utf8_lossy(&diff.stdout));
-    println!("stderr:\n{}", String::from_utf8_lossy(&diff.stderr));
+    for (h, d) in [("stdout", &diff.stdout), ("stderr", &diff.stderr)] {
+        if !d.is_empty() {
+            println!("{}:{}", h, String::from_utf8_lossy(d));
+        }
+    }
     assert!(diff.status.success());
 
     Ok(devices)
@@ -69,7 +72,7 @@ fn test_generation(path: &str) -> Result<Vec<config::Device>> {
 fn test_01_basic() {
     let devices = test_generation("tests/01-basic").unwrap();
     assert_eq!(devices.len(), 1);
-    let d = devices.iter().next().unwrap();
+    let d = &devices[0];
     assert!(d.is_swap());
     assert_eq!(d.host_memory_limit_mb, None);
     assert_eq!(d.zram_fraction, 0.5);
@@ -80,7 +83,7 @@ fn test_01_basic() {
 fn test_02_zstd() {
     let devices = test_generation("tests/02-zstd").unwrap();
     assert_eq!(devices.len(), 1);
-    let d = devices.iter().next().unwrap();
+    let d = &devices[0];
     assert!(d.is_swap());
     assert_eq!(d.host_memory_limit_mb.unwrap(), 2050);
     assert_eq!(d.zram_fraction, 0.75);
@@ -128,7 +131,7 @@ fn test_05_kernel_disabled() {
 fn test_06_kernel_enabled() {
     let devices = test_generation("tests/06-kernel-enabled").unwrap();
     assert_eq!(devices.len(), 1);
-    let d = devices.iter().next().unwrap();
+    let d = &devices[0];
     assert!(d.is_swap());
     assert_eq!(d.host_memory_limit_mb, None);
     assert_eq!(d.zram_fraction, 0.5);
@@ -195,7 +198,7 @@ fn test_07_devices(devices: Vec<config::Device>) {
 fn test_08_plain_device() {
     let devices = test_generation("tests/08-plain-device").unwrap();
     assert_eq!(devices.len(), 1);
-    let d = devices.iter().next().unwrap();
+    let d = &devices[0];
     assert!(!d.is_swap());
     assert_eq!(d.host_memory_limit_mb, None);
     assert_eq!(d.zram_fraction, 0.5);

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -5,6 +5,7 @@ use zram_generator::{config, generator};
 use anyhow::Result;
 use fs_extra::dir::{copy, CopyOptions};
 use std::fs;
+use std::io::{self, Write};
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -150,6 +151,9 @@ fn test_07_mount_point() {
 #[test]
 fn test_07a_mount_point_excl() {
     if !Path::new("tests/07a-mount-point-excl").exists() {
+        io::stdout()
+            .write_all(b"07a-mount-point-excl doesn't exist: assuming package, skipping\n")
+            .unwrap();
         return;
     }
 


### PR DESCRIPTION
(and spell `&devices[0]` `&devices[0]`)

The test output with a removed 07a directory is such now, which is a far cry from actually saying `test test_07a_mount_point_excl ... skipped`, but is actually noted at least:
```
nabijaczleweli@tarta:~/code/systemd-zram-generator$ SYSTEMD_UTIL_DIR=$(pkg-config --variable=systemdutildir systemd) cargo test --release
   Compiling zram-generator v1.0.1 (/home/nabijaczleweli/code/systemd-zram-generator)
    Finished release [optimized] target(s) in 1.75s
     Running unittests (target/release/deps/zram_generator-d1b62b1787f2545a)

running 7 tests
test config::tests::test_get_total_memory_kb ... ok
test generator::tests::test_mount_unit_name ... ok
test config::tests::test_kernel_has_no_option ... ok
test config::tests::test_verify_mount_point ... ok
test config::tests::test_get_total_memory_not_found - should panic ... ok
test config::tests::test_kernel_has_option ... ok
test generator::tests::test_parse_known_compressors ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/zram_generator-09da8f38cdd949bc)

running 7 tests
test config::tests::test_get_total_memory_kb ... ok
test config::tests::test_kernel_has_no_option ... ok
test config::tests::test_kernel_has_option ... ok
test config::tests::test_verify_mount_point ... ok
test config::tests::test_get_total_memory_not_found - should panic ... ok
test generator::tests::test_mount_unit_name ... ok
test generator::tests::test_parse_known_compressors ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_cases.rs (target/release/deps/test_cases-3a9c1650f8088c2c)

running 9 tests
07a-mount-point-excl doesn't exist: assuming package, skipping
test test_07a_mount_point_excl ... ok
test test_05_kernel_disabled ... ok
test test_03_too_much_memory ... ok
test test_08_plain_device ... ok
test test_01_basic ... ok
test test_06_kernel_enabled ... ok
test test_07_mount_point ... ok
test test_02_zstd ... ok
test test_04_dropins ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

   Doc-tests zram-generator

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```