### PR TITLE
Actually run kloppy, fix it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,5 @@ jobs:
           override: true
           profile: minimal
           components: clippy
-      - name: Check formatting
-        uses: actions-rs/clippy@master
-        with:
-          args: -- -D warnings
+      - name: Validate clippy
+        run: SYSTEMD_UTIL_DIR=/ cargo clippy -- -D warnings

--- a/src/config.rs
+++ b/src/config.rs
@@ -172,14 +172,14 @@ impl fasteval::EvalNamespace for RamNs {
 }
 
 pub fn read_device(root: &Path, kernel_override: bool, name: &str) -> Result<Option<Device>> {
-    let memtotal_mb = get_total_memory_kb(&root)? as f64 / 1024.;
+    let memtotal_mb = get_total_memory_kb(root)? as f64 / 1024.;
     Ok(read_devices(root, kernel_override, memtotal_mb as u64)?
         .remove(name)
         .filter(|dev| dev.disksize > 0))
 }
 
 pub fn read_all_devices(root: &Path, kernel_override: bool) -> Result<Vec<Device>> {
-    let memtotal_mb = get_total_memory_kb(&root)? as f64 / 1024.;
+    let memtotal_mb = get_total_memory_kb(root)? as f64 / 1024.;
     Ok(read_devices(root, kernel_override, memtotal_mb as u64)?
         .into_iter()
         .filter(|(_, dev)| dev.disksize > 0)

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -233,7 +233,7 @@ fn mount_unit_name(path: &Path) -> String {
 
     let trimmed = path.to_str().unwrap().trim_matches('/');
     if trimmed.is_empty() {
-        return "-.mount".to_string();
+        "-.mount".to_string()
     } else {
         let mut obuf = Vec::with_capacity(path.as_os_str().len() + ".mount".len());
         let mut just_slash = false;
@@ -288,7 +288,7 @@ BindsTo={}
 
     write_contents(
         output_directory,
-        &mount_name,
+        mount_name,
         &format!(
             "\
 [Unit]


### PR DESCRIPTION
Cf. this hidden failure, for example: https://github.com/systemd/zram-generator/runs/4083411091?check_suite_focus=true#step:4:81

We haven't been running clippy since we started to require `$SYSTEMD_UTIL_DIR` – ff4fb9b51e256b6543485be59d6ec5cdf7228739

~~#124 is clippy-clean, too, so these can be merged independently~~ Conflicts with #124, this needs to go first