### PR TITLE
Revert "Cargo.toml: lto = "thin"" to = true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nix = "0.23"
 ctor = "0.1"
 
 [profile.release]
-lto = "thin"
+lto = true
 opt-level = "z"
 codegen-units = 1
 panic = "abort"


### PR DESCRIPTION
Fat LTO works on bullseye amd64 and i386, sid amd64, i386, and x32, and focal amd64 (I haven't managed to strap impish, something about base-files being SNAFUd or whatever)

Sizing is quite significant in apparent (250k), and still quite good in real (40k):
```
nabijaczleweli@tarta:~/code/systemd-zram-generator$ l thin true 
-rwxr-xr-x 1 nabijaczleweli users 903K Nov 16 20:21 thin
-rwxr-xr-x 1 nabijaczleweli users 759K Nov 16 20:23 true
nabijaczleweli@tarta:~/code/systemd-zram-generator$ du -h thin true 
441K    thin
405K    true
nabijaczleweli@tarta:~/code/systemd-zram-generator$ size thin true 
   text    data     bss     dec     hex filename
 868823   45361     776  914960   df610 thin
 735002   31137     776  766915   bb3c3 true
```

This reverts PR #93.