### PR TITLE
Update my author mail, add Aqs around README mails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "zram-generator"
 version = "1.1.0"
 authors = ["Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>",
            "Igor Raits <i.gnatenko.brain@gmail.com>",
-           "наб <nabijaczleweli@gmail.com>"]
+           "наб <nabijaczleweli@nabijaczleweli.xyz>"]
 license = "MIT"
 description = "Systemd unit generator for zram swap devices."
 homepage = "https://github.com/systemd/zram-generator"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,6 @@ can be substituted for a non-standard location of the binary for testing.
 
 ### Authors
 
-Written by Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>,
-Igor Raits <i.gnatenko.brain@gmail.com>, наб <nabijaczleweli@nabijaczleweli.xyz>, and others.
+Written by Zbigniew Jędrzejewski-Szmek &lt;<zbyszek@in.waw.pl>&gt;,
+Igor Raits &lt;<i.gnatenko.brain@gmail.com>&gt;, наб &lt;<nabijaczleweli@nabijaczleweli.xyz>&gt;, and others.
 See https://github.com/systemd/zram-generator/graphs/contributors for the full list.

--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ can be substituted for a non-standard location of the binary for testing.
 ### Authors
 
 Written by Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>,
-Igor Raits <i.gnatenko.brain@gmail.com>, наб <nabijaczleweli@gmail.com>, and others.
+Igor Raits <i.gnatenko.brain@gmail.com>, наб <nabijaczleweli@nabijaczleweli.xyz>, and others.
 See https://github.com/systemd/zram-generator/graphs/contributors for the full list.


### PR DESCRIPTION
I woulda included this in some other PR but I only noticed this now when reading my debian package and I don't seem to have any other ones rn, so

Also, the literal `name address@domain` looks weird unstructured – update it to use the classic `name <address@domain>` formatting.