### PR TITLE
Bump minimum rust-ini to 0.15, first one with ordered keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests/07a-mount-point-excl", "tests/10-example"]
 anyhow = "1.0.12"
 clap = { version = "2.33", default-features = false }
 liboverdrop = "0.0.2"
-rust-ini = ">=0.13, <0.18"
+rust-ini = ">=0.15, <0.18"
 log = { version = "0.4", features = ["std"] }
 fasteval = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
See #134