### PR TITLE
Update install from source instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ It is recommended to use an existing package:
 * Debian: packages provided by nabijaczleweli, see https://debian.nabijaczleweli.xyz/README.
 * Arch: `sudo pacman -S zram-generator` (or https://aur.archlinux.org/packages/zram-generator-git/ for the latest git commit)
 
-To install directly from sources, execute `make build && sudo make install`:
+To install directly from sources, execute `make build && sudo make install NOBUILD=true`:
 * `zram-generator` binary is installed in the systemd system generator directory (usually `/usr/lib/systemd/system-generators/`)
 * `zram-generator(8)` and `zram-generator.conf(5)` manpages are installed into `/usr/share/man/manN/`, this requires [`ronn`](https://github.com/apjanke/ronn-ng).
 * `units/systemd-zram-setup@.service` is copied into the systemd system unit directory (usually `/usr/lib/systemd/system/`)


### PR DESCRIPTION
NOBUILD=true is necessary if sudo does not have cargo in its PATH, which is quite common.