### PR TITLE
fixup: warning on clippy (src/kernlog.rs)

### DIFF
--- a/src/kernlog.rs
+++ b/src/kernlog.rs
@@ -68,7 +68,8 @@ impl log::Log for KernelLog {
         }
 
         if let Ok(mut kmsg) = self.kmsg.lock() {
-            match kmsg.as_mut() {
+            let is_as_mut = kmsg.as_mut();
+            match is_as_mut {
                 Some(kmsg) => _write_kmsg(kmsg, record),
                 None => _write_stdout(record),
             }


### PR DESCRIPTION
This PR will fix the warning which is often showing on the CI
```
error: temporary with significant drop in match scrutinee
--> src/kernlog.rs:71:19
|
71|            match kmsg.as_mut() {
| ^^^^^^^^^^^^^
```