### PR TITLE
Include link to puppet-zram_generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ To install directly from sources, execute `make build && sudo make install NOBUI
 * `zram-generator.conf.example` is copied into `/usr/share/doc/zram-generator/`
 You need though create your own config file at one of the locations listed above.
 
+To install and configure with puppet [puppet-zram_generator](https://github.com/voxpupuli/puppet-zram_generator) is available.
+
 #### tl;dr
 
 - Install `zram-generator` using one of the methods listed above.


### PR DESCRIPTION
Include a link to the recently published puppet-zram-generator

https://github.com/voxpupuli/puppet-zram_generator

Mostly just letting you know - will not be sad if not merged.