### PR TITLE
[Clippy] fixup: the borrowed expression implements the required traits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -393,7 +393,7 @@ fn parse_line(dev: &mut Device, key: &str, value: &str) -> Result<()> {
 
 fn _get_total_memory_kb(path: &Path) -> Result<u64> {
     for line in
-        BufReader::new(fs::File::open(&path).with_context(|| {
+        BufReader::new(fs::File::open(path).with_context(|| {
             format!("Failed to read memory information from {}", path.display())
         })?)
         .lines()

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -15,7 +15,7 @@ fn make_parent(of: &Path) -> Result<()> {
     let parent = of
         .parent()
         .ok_or_else(|| anyhow!("Couldn't get parent of {}", of.display()))?;
-    fs::create_dir_all(&parent)?;
+    fs::create_dir_all(parent)?;
     Ok(())
 }
 
@@ -314,7 +314,7 @@ Options={options}
     /* enablement symlink */
     let symlink_path = output_directory
         .join("local-fs.target.wants")
-        .join(&mount_name);
+        .join(mount_name);
     let target_path = format!("../{}", mount_name);
     make_symlink(&target_path, &symlink_path)?;
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -26,7 +26,7 @@ pub fn run_device_setup(device: Option<Device>, device_name: &str) -> Result<()>
 
     if let Some(ref compression_algorithm) = device.compression_algorithm {
         let comp_algorithm_path = device_sysfs_path.join("comp_algorithm");
-        match fs::write(&comp_algorithm_path, &compression_algorithm) {
+        match fs::write(&comp_algorithm_path, compression_algorithm) {
             Ok(_) => {}
             Err(err) if err.kind() == ErrorKind::InvalidInput => {
                 warn!(


### PR DESCRIPTION
error: could not compile `zram-generator` due to 4 previous errors.
This PR will fix this.