### PR TITLE
fixup: reported improvements by Clippy

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -139,7 +139,7 @@ impl fmt::Display for Device {
         if self.zram_fraction.is_some() || self.max_zram_size_mb.is_some() {
             f.write_str(" (")?;
             if let Some(zf) = self.zram_fraction {
-                write!(f, "zram-fraction={}", zf)?;
+                write!(f, "zram-fraction={zf}")?;
             }
             if self.max_zram_size_mb.is_some() {
                 f.write_str(" ")?;
@@ -157,7 +157,7 @@ struct OptMB(Option<u64>);
 impl fmt::Display for OptMB {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            Some(val) => write!(f, "{}MB", val),
+            Some(val) => write!(f, "{val}MB"),
             None => f.write_str("<none>"),
         }
     }
@@ -287,7 +287,7 @@ fn parse_optional_size(val: &str) -> Result<Option<u64>> {
     } else {
         Some(
             val.parse()
-                .with_context(|| format!("Failed to parse optional size \"{}\"", val))?,
+                .with_context(|| format!("Failed to parse optional size \"{val}\""))?,
         )
     })
 }
@@ -295,7 +295,7 @@ fn parse_optional_size(val: &str) -> Result<Option<u64>> {
 fn parse_swap_priority(val: &str) -> Result<i32> {
     let val = val
         .parse()
-        .with_context(|| format!("Failed to parse priority \"{}\"", val))?;
+        .with_context(|| format!("Failed to parse priority \"{val}\""))?;
 
     /* See --priority in swapon(8). */
     match val {
@@ -366,7 +366,7 @@ fn parse_line(dev: &mut Device, key: &str, value: &str) -> Result<()> {
             dev.zram_fraction = Some(
                 value
                     .parse()
-                    .with_context(|| format!("Failed to parse zram-fraction \"{}\"", value))
+                    .with_context(|| format!("Failed to parse zram-fraction \"{value}\""))
                     .and_then(|f| {
                         if f >= 0. {
                             Ok(f)

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -101,10 +101,7 @@ pub fn run_generator(devices: &[Device], output_directory: &Path, fake_mode: boo
             })
             .fold(0, cmp::max);
 
-        if !Path::new("/dev")
-            .join(format!("zram{}", max_device))
-            .exists()
-        {
+        if !Path::new("/dev").join(format!("zram{max_device}")).exists() {
             while fs::read_to_string("/sys/class/zram-control/hot_add")
                 .context("Adding zram device")?
                 .trim_end()
@@ -128,7 +125,7 @@ pub fn run_generator(devices: &[Device], output_directory: &Path, fake_mode: boo
         let known = parse_known_compressors(&proc_crypto);
 
         for comp in compressors.difference(&known) {
-            modprobe(&format!("crypto-{}", comp), false);
+            modprobe(&format!("crypto-{comp}"), false);
         }
     }
 
@@ -140,7 +137,6 @@ fn parse_known_compressors(proc_crypto: &str) -> BTreeSet<&str> {
     // Extract algorithm names (this includes non-compression algorithms too)
     proc_crypto
         .lines()
-        .into_iter()
         .filter(|line| line.starts_with("name"))
         .map(|m| m.rsplit(':').next().unwrap().trim())
         .collect()
@@ -237,7 +233,7 @@ Options={options}
 
     /* enablement symlink */
     let symlink_path = output_directory.join("swap.target.wants").join(&swap_name);
-    let target_path = format!("../{}", swap_name);
+    let target_path = format!("../{swap_name}");
     make_symlink(&target_path, &symlink_path)?;
 
     Ok(())
@@ -251,7 +247,7 @@ fn unit_name_from_path(path: &Path, suffix: &str) -> String {
 
     let trimmed = path.to_str().unwrap().trim_matches('/');
     if trimmed.is_empty() {
-        format!("-{}", suffix)
+        format!("-{suffix}")
     } else {
         let mut obuf = Vec::with_capacity(path.as_os_str().len() + suffix.len());
         let mut just_slash = false;
@@ -264,7 +260,7 @@ fn unit_name_from_path(path: &Path, suffix: &str) -> String {
                 b'/' => obuf.push(b'-'),
                 b'.' if i == 0 => write!(obuf, "\\x{:02x}", b'.').unwrap(),
                 b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b':' | b'_' | b'.' => obuf.push(b),
-                _ => write!(obuf, "\\x{:02x}", b).unwrap(),
+                _ => write!(obuf, "\\x{b:02x}").unwrap(),
             }
         }
         obuf.extend_from_slice(suffix.as_bytes());
@@ -315,7 +311,7 @@ Options={options}
     let symlink_path = output_directory
         .join("local-fs.target.wants")
         .join(mount_name);
-    let target_path = format!("../{}", mount_name);
+    let target_path = format!("../{mount_name}");
     make_symlink(&target_path, &symlink_path)?;
 
     Ok(())

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -77,13 +77,7 @@ pub fn run_device_setup(device: Option<Device>, device_name: &str) -> Result<()>
                                                             this expect() will never panic, save for an stdlib bug"))),
             },
         Err(e) =>
-            Err(e).with_context(|| {
-                format!(
-                    "{} call failed for /dev/{}",
-                    SYSTEMD_MAKEFS_COMMAND,
-                    device_name
-                )
-            }),
+            Err(e).with_context(|| format!("{SYSTEMD_MAKEFS_COMMAND} call failed for /dev/{device_name}")),
     }
 }
 


### PR DESCRIPTION
 Added in: **1.65.0**
`uninlined_format_args`
**What it does?**
Detect when a variable is not inlined in a format string, and suggests to inline it.
**Why is this bad?**
Non-inlined code is slightly more difficult to read and understand, as it requires arguments to be matched against the format string. The inlined syntax, where allowed, is simpler.

**Examples:**

```
format!("{}", var);
format!("{v:?}", v = var);
format!("{0} {0}", var);
format!("{0:1$}", var, width);
format!("{:.*}", prec, var);
```
Use instead:
```
format!("{var}");
format!("{var:?}");
format!("{var} {var}");
format!("{var:width$}");
format!("{var:.prec$}");
```

If allow-mixed-uninlined-format-args is set to false in clippy.toml, the following code will also trigger the lint:
`format!("{} {}", var, 1+2);`
Use instead:
`format!("{var} {}", 1+2);`
