### PR TITLE
Fixup: useless conversion to the same type: `std::str::Lines<'_>`

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -140,7 +140,6 @@ fn parse_known_compressors(proc_crypto: &str) -> BTreeSet<&str> {
     // Extract algorithm names (this includes non-compression algorithms too)
     proc_crypto
         .lines()
-        .into_iter()
         .filter(|line| line.starts_with("name"))
         .map(|m| m.rsplit(':').next().unwrap().trim())
         .collect()


### PR DESCRIPTION
consider removing `.into_iter()`