### PR TITLE
CI: make sure to always use the latest rust-tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Install Rust
         run: |
           rm -f /home/runner/.cargo/bin/*fmt
+          rm -f /home/runner/.cargo/bin/rust-analyzer
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: | 
@@ -54,6 +55,7 @@ jobs:
       - name: Install Rust
         run: |
           rm -f /home/runner/.cargo/bin/*fmt
+          rm -f /home/runner/.cargo/bin/rust-analyzer
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: |
@@ -71,6 +73,7 @@ jobs:
       - name: Install Rust
         run: |
           rm -f /home/runner/.cargo/bin/*fmt
+          rm -f /home/runner/.cargo/bin/rust-analyzer
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: | 


### PR DESCRIPTION
warning: tool `rust-analyzer` is already installed, remove it from `/home/runner/.cargo/bin`, then run `rustup update` to have rustup manage this tool.
Make sure to always use the latest rust-tools.