### PR TITLE
CI: optimize removal of older rust binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: sudo modprobe -v zram
       - name: Install Rust
         run: |
-          rm -f ~/.cargo/bin/*fmt ~/.cargo/bin/rust-analyzer
+          rm -f ~/.cargo/bin/{*fmt,rust-analyzer}
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: | 
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Rust
         run: |
-          rm -f ~/.cargo/bin/*fmt ~/.cargo/bin/rust-analyzer
+          rm -f ~/.cargo/bin/{*fmt,rust-analyzer}
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: |
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Rust
         run: |
-          rm -f ~/.cargo/bin/*fmt ~/.cargo/bin/rust-analyzer
+          rm -f ~/.cargo/bin/{*fmt,rust-analyzer}
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: | 


### PR DESCRIPTION
one `rm -rf ...` line instead of 2 or more later.
Before:
```
rm -f /home/runner/.cargo/bin/*fmt
rm -f ~/.cargo/bin/*fmt ~/.cargo/bin/rust-analyzer
```
After:
```
rm -f ~/.cargo/bin/{*fmt,rust-analyzer}
```