### PR TITLE
Added configuration option for setting mem_limit in /sys/block/zramX/…

### DIFF
--- a/man/zram-generator.conf.md
+++ b/man/zram-generator.conf.md
@@ -62,6 +62,14 @@ Devices with the final size of *0* will be discarded.
 
   Defaults to *min(ram / 2, 4096)*.
 
+* `zram-resident-limit`=
+
+  Sets the maximum resident memory limit of the zram device as a function of *MemTotal*, available as the `ram` variable.
+
+  Arithmetic operators (^%/\*-+), e, π, SI suffixes, log(), int(), ceil(), floor(), round(), abs(), min(), max(), and trigonometric functions are supported.
+
+  Defaults to *0* meaning there is no limit, usefull to set when having zram device bigger than available RAM.
+
 * `compression-algorithm`=
 
   Specifies the algorithm used to compress the zram device.

--- a/man/zram-generator.conf.md
+++ b/man/zram-generator.conf.md
@@ -58,17 +58,17 @@ Devices with the final size of *0* will be discarded.
 
   Sets the size of the zram device as a function of *MemTotal*, available as the `ram` variable.
 
-  Arithmetic operators (^%/\*-+), e, π, SI suffixes, log(), int(), ceil(), floor(), round(), abs(), min(), max(), and trigonometric functions are supported.
-
+  Arithmetic operators (^%/\*-+), e, π, SI suffixes, log(), int(), ceil(), floor(), round(), abs(), min(), max(), and trigonometric functions are supported. 
+  
   Defaults to *min(ram / 2, 4096)*.
 
 * `zram-resident-limit`=
 
   Sets the maximum resident memory limit of the zram device as a function of *MemTotal*, available as the `ram` variable.
 
-  Arithmetic operators (^%/\*-+), e, π, SI suffixes, log(), int(), ceil(), floor(), round(), abs(), min(), max(), and trigonometric functions are supported.
+  Same format as *zram-size*.
 
-  Defaults to *0* meaning there is no limit, usefull to set when having zram device bigger than available RAM.
+  Defaults to *0* (no limit).
 
 * `compression-algorithm`=
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
 
-use anyhow::{anyhow, Context, Result, Error};
+use anyhow::{anyhow, Context, Error, Result};
 use fasteval::Evaler;
 use ini::Ini;
 use log::{info, warn};
@@ -93,10 +93,15 @@ impl Device {
         }
     }
 
-    fn process_size(&self, zram_option: &Option<(String, fasteval::ExpressionI,
-                  fasteval::Slab)>, memtotal_mb: f64, name: &str, default_size: f64,
-                  label: &str) -> Result<u64, Error> {
-        return Ok(( match zram_option {
+    fn process_size(
+        &self,
+        zram_option: &Option<(String, fasteval::ExpressionI, fasteval::Slab)>,
+        memtotal_mb: f64,
+        name: &str,
+        default_size: f64,
+        label: &str,
+    ) -> Result<u64, Error> {
+        return Ok((match zram_option {
             Some(zs) => {
                 zs.1.from(&zs.2.ps)
                     .eval(&zs.2, &mut RamNs(memtotal_mb))
@@ -110,7 +115,8 @@ impl Device {
                     })?
             }
             None => default_size,
-        } * 1024.0 * 1024.0) as u64);
+        } * 1024.0
+            * 1024.0) as u64);
     }
 
     fn set_disksize_if_enabled(&mut self, memtotal_mb: u64) -> Result<()> {
@@ -125,11 +131,20 @@ impl Device {
                 .min(max_mb)
                 * (1024 * 1024);
         } else {
-            self.disksize = self.process_size(&self.zram_size, memtotal_mb as f64, &self.name, 
-                                              (memtotal_mb as f64 / 2.).min(4096.), "zram-size")?;
-            self.mem_limit = self.process_size(&self.zram_resident_limit, 
-                                               memtotal_mb as f64, &self.name, 0.,
-                                               "zram-resident-limit")?;
+            self.disksize = self.process_size(
+                &self.zram_size,
+                memtotal_mb as f64,
+                &self.name,
+                (memtotal_mb as f64 / 2.).min(4096.),
+                "zram-size",
+            )?;
+            self.mem_limit = self.process_size(
+                &self.zram_resident_limit,
+                memtotal_mb as f64,
+                &self.name,
+                0.,
+                "zram-resident-limit",
+            )?;
         }
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,7 @@ impl Device {
         default_size: f64,
         label: &str,
     ) -> Result<u64, Error> {
-        return Ok((match zram_option {
+        Ok((match zram_option {
             Some(zs) => {
                 zs.1.from(&zs.2.ps)
                     .eval(&zs.2, &mut RamNs(memtotal_mb))
@@ -116,7 +116,7 @@ impl Device {
             }
             None => default_size,
         } * 1024.0
-            * 1024.0) as u64);
+            * 1024.0) as u64)
     }
 
     fn set_disksize_if_enabled(&mut self, memtotal_mb: u64) -> Result<()> {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -57,6 +57,14 @@ pub fn run_device_setup(device: Option<Device>, device_name: &str) -> Result<()>
         }
     }
 
+    let resident_memory = device_sysfs_path.join("mem_limit");
+    fs::write(&resident_memory, format!("{}", device.mem_limit)).with_context(|| {
+        format!(
+            "Failed to configure zram maximum resident memory limit into {}",
+            resident_memory.display()
+        )
+    })?;
+    
     let disksize_path = device_sysfs_path.join("disksize");
     fs::write(&disksize_path, format!("{}", device.disksize)).with_context(|| {
         format!(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -64,7 +64,7 @@ pub fn run_device_setup(device: Option<Device>, device_name: &str) -> Result<()>
             resident_memory.display()
         )
     })?;
-    
+
     let disksize_path = device_sysfs_path.join("disksize");
     fs::write(&disksize_path, format!("{}", device.disksize)).with_context(|| {
         format!(

--- a/zram-generator.conf.example
+++ b/zram-generator.conf.example
@@ -19,12 +19,12 @@ host-memory-limit = 9048
 # The default is "min(ram / 2, 4096)".
 zram-size = min(ram / 10, 2048)
 
-# The maximum size of resident memory of zram device, as function of 
-# MemTotal, both in MB. For example, if the machine has 1GiB, and 
-# zram-resident-limit=ram/8, then the resident space on RAM won't
-# exceed 64MiB. Recomended value is ram / 2.
+# The maximum memory resident for this zram device, as a function of MemTotal, 
+# both in MB. 
+# For example, if the machine has 1 GiB, and zram-resident-limit=ram/8,
+# then the resident space on RAM won't exceed 128 MiB.
 #
-# The default is "0"
+# The default is "0" (no limit).
 zram-resident-limit = 0
 
 # The compression algorithm to use for the zram device,

--- a/zram-generator.conf.example
+++ b/zram-generator.conf.example
@@ -19,6 +19,14 @@ host-memory-limit = 9048
 # The default is "min(ram / 2, 4096)".
 zram-size = min(ram / 10, 2048)
 
+# The maximum size of resident memory of zram device, as function of 
+# MemTotal, both in MB. For example, if the machine has 1GiB, and 
+# zram-resident-limit=ram/8, then the resident space on RAM won't
+# exceed 64MiB. Recomended value is ram / 2.
+#
+# The default is "0"
+zram-resident-limit = 0
+
 # The compression algorithm to use for the zram device,
 # or leave unspecified to keep the kernel default.
 compression-algorithm = lzo-rle


### PR DESCRIPTION
…mem_limit, needed in cases when

zram device size is big with compression ratios that can't be fit in RAM yet zram device does not report as being full. Option is "zram-resident-limit = " and syntax is same as with setting 'zram-size ='. Tested on my system and works as expected, additional test may be needed.

