### PR TITLE
ci.yml: remove any pre-existing rust tools first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           sudo modprobe -v zram
       - name: Install Rust
         run: |
-          rm -f ~/.cargo/bin/*fmt ~/.cargo/bin/rust-analyzer
+          rm -f ~/.cargo/bin/*
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: | 
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust
         run: |
-          rm -f ~/.cargo/bin/*fmt ~/.cargo/bin/rust-analyzer
+          rm -f ~/.cargo/bin/*
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: |
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust
         run: |
-          rm -f ~/.cargo/bin/*fmt ~/.cargo/bin/rust-analyzer
+          rm -f ~/.cargo/bin/*
           curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install toolchain
         run: | 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,11 @@ jobs:
         uses: tecolicom/actions-use-apt-tools@main
         with:
           tools: linux-modules-extra-$(uname -r)
-      - name: Insert zram module
+      - name: Insert required modules
         run: |
           sudo depmod
           sudo modprobe -v zram
+          sudo modprobe -v zstd
       - name: Install Rust
         run: |
           rm -f ~/.cargo/bin/*


### PR DESCRIPTION
rustup can not handle the pre-existing rust bins during update so they have to be removed.
We can skip this by removing all pre-existing rust bins and install them via rustup