### PR TITLE
generator.rs: `FromIterator` is imported redundantly

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -323,6 +323,7 @@ Options={options}
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[allow(unused_imports)]
     use std::iter::FromIterator;
 
     #[test]


### PR DESCRIPTION
Until now only affects rust beta and nightly.