### PR TITLE
Allow multiple whitespace-separated compression-algorithm=s, and give the ones after the first one to /recomp_algorithm

### DIFF
--- a/man/zram-generator.conf.md
+++ b/man/zram-generator.conf.md
@@ -72,10 +72,14 @@ Devices with the final size of *0* will be discarded.
 
   Specifies the algorithm used to compress the zram device.
 
-  This takes a literal string, representing the algorithm to use.<br />
-  Consult */sys/block/zram0/comp_algorithm* for a list of currently loaded compression algorithms, but note that additional ones may be loaded on demand.
+  This takes a whitespace-separated list string, representing the algorithms to use, and parameters in parenteses.<br />
+  Consult */sys/block/zram0/comp_algorithm* (and *.../recomp_algorithm*) for a list of currently loaded compression algorithms, but note that additional ones may be loaded on demand.
 
-  If unset, none will be configured and the kernel's default will be used.
+  If unset, none will be configured and the kernel's default will be used.<br />
+  If more than one is given, and recompression is enabled in the kernel, subsequent ones will be set as the recompression algorithms, with decreasing priority.
+
+  If a compression algorithm is suffixed with a parenthesised comma-separated list of parameters, those are given to `.../algorithm_params` (and `.../recompress`).
+  A parenthesised parameter list *without* a compression algorithm is set as the global recompression parameters.
 
 * `writeback-device`=
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -117,7 +117,13 @@ pub fn run_generator(devices: &[Device], output_directory: &Path, fake_mode: boo
 
     let compressors: BTreeSet<_> = devices
         .iter()
-        .flat_map(|device| device.compression_algorithm.as_deref())
+        .flat_map(|device| {
+            device
+                .compression_algorithms
+                .compression_algorithms
+                .iter()
+                .map(|(a, _)| a.as_ref())
+        })
         .collect();
 
     if !compressors.is_empty() {

--- a/tests/09-zram-size/etc/systemd/zram-generator.conf
+++ b/tests/09-zram-size/etc/systemd/zram-generator.conf
@@ -1,4 +1,4 @@
 [zram0]
-compression-algorithm = zstd
+compression-algorithm = zstd(dictionary=/etc/gaming,level=9) (recompargs)
 host-memory-limit = 2050
 zram-size = min(0.75 * ram, 6000)

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -124,7 +124,13 @@ fn test_02_zstd() {
     assert!(d.is_swap());
     assert_eq!(d.host_memory_limit_mb, Some(2050));
     assert_eq!(d.zram_size.as_ref().map(z_s_name), Some("ram * 0.75"));
-    assert_eq!(d.compression_algorithm.as_ref().unwrap(), "zstd");
+    assert_eq!(
+        d.compression_algorithms,
+        config::Algorithms {
+            compression_algorithms: vec![("zstd".into(), "".into())],
+            ..Default::default()
+        }
+    );
     assert_eq!(d.options, "discard");
 }
 
@@ -259,7 +265,13 @@ fn test_09_zram_size() {
         d.zram_size.as_ref().map(z_s_name),
         Some("min(0.75 * ram, 6000)")
     );
-    assert_eq!(d.compression_algorithm.as_ref().unwrap(), "zstd");
+    assert_eq!(
+        d.compression_algorithms,
+        config::Algorithms {
+            compression_algorithms: vec![("zstd".into(), "dictionary=/etc/gaming level=9".into())],
+            recompression_global: "recompargs".into()
+        }
+    );
 }
 
 #[test]
@@ -283,7 +295,16 @@ fn test_10_example() {
                     d.zram_size.as_ref().map(z_s_name),
                     Some("min(ram / 10, 2048)")
                 );
-                assert_eq!(d.compression_algorithm.as_deref(), Some("lzo-rle"));
+                assert_eq!(
+                    d.compression_algorithms,
+                    config::Algorithms {
+                        compression_algorithms: vec![
+                            ("lzo-rle".into(), "".into()),
+                            ("zstd".into(), "level=3".into())
+                        ],
+                        recompression_global: "type=idle".into(),
+                    }
+                );
                 assert_eq!(d.options, "");
             }
             "zram1" => {

--- a/zram-generator.conf.example
+++ b/zram-generator.conf.example
@@ -29,7 +29,13 @@ zram-resident-limit = 0
 
 # The compression algorithm to use for the zram device,
 # or leave unspecified to keep the kernel default.
-compression-algorithm = lzo-rle
+#
+# Subsequent algorithms are used for recompression.
+# Comma-separated parameters may be specified in parentheses.
+#
+# Parameters without a compression algorithm are set as
+# global recompression parameters.
+compression-algorithm = lzo-rle zstd(level=3) (type=idle)
 
 # By default, file systems and swap areas are trimmed on-the-go
 # by setting "discard".


### PR DESCRIPTION
Ref: https://github.com/systemd/zram-generator/issues/178#issuecomment-2361314574

I've tested the error case, @OmegaSquad82 needs to test the "actually setting it" case.

A config like
```
compression-algorithm = a b c
```
was previously "compress with `a b c`" (naturally invalid) and is now "compress with `a`, recompress with `b` then `c`"