### PR TITLE
Cargo.toml: bump fs_extra version to 1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fasteval = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"
-fs_extra = "1.1"
+fs_extra = "1.3"
 nix = ">=0.22, <0.24"
 ctor = "0.1"
 


### PR DESCRIPTION
The old version generates warnings about future incompatibility.