### PR TITLE
Allow "set!var = program" at top level that makes var = eval(system(program))

### DIFF
--- a/man/index.txt
+++ b/man/index.txt
@@ -3,6 +3,7 @@ zram-generator.conf(5)  zram-generator.conf.5.ronn
 
 modprobe(8)             https://man7.org/linux/man-pages/man8/modprobe.8.html
 proc(5)                 https://man7.org/linux/man-pages/man5/proc.5.html
+system(3)               https://man7.org/linux/man-pages/man3/system.3.html
 
 systemd-detect-virt(1)  https://freedesktop.org/software/systemd/man/systemd-detect-virt.html
 systemd.generator(7)    https://freedesktop.org/software/systemd/man/systemd.generator.html

--- a/man/zram-generator.conf.md
+++ b/man/zram-generator.conf.md
@@ -42,7 +42,7 @@ This option thus has higher priority than the configuration files.
 
 ## OPTIONS
 
-Each device is configured independently in its `[zramN]` section, where N is a nonnegative integer. Other sections are ignored.
+Each device is configured independently in its `[zramN]` section, where N is a nonnegative integer. The global section may contain [DIRECTIVES]. Other sections are ignored.
 
 Devices with the final size of *0* will be discarded.
 
@@ -57,6 +57,7 @@ Devices with the final size of *0* will be discarded.
 * `zram-size`=
 
   Sets the size of the zram device as a function of *MemTotal*, available as the `ram` variable.
+  Additional variables may be provided by [DIRECTIVES].
 
   Arithmetic operators (^%/\*-+), e, π, SI suffixes, log(), int(), ceil(), floor(), round(), abs(), min(), max(), and trigonometric functions are supported.
 
@@ -66,7 +67,7 @@ Devices with the final size of *0* will be discarded.
 
   Sets the maximum resident memory limit of the zram device (or *0* for no limit) as a function of *MemTotal*, available as the `ram` variable.
 
-  Same format as *zram-size*. Defaults to *0*.
+  Same format as `zram-size`. Defaults to *0*.
 
 * `compression-algorithm`=
 
@@ -116,6 +117,17 @@ Devices with the final size of *0* will be discarded.
   Sets mount or swapon options. Availability depends on `fs-type`.
 
   Defaults to *discard*.
+
+## DIRECTIVES
+
+The global section (before any section header) may contain directives in the following form:
+
+* `set!`*variable*=*program*
+
+  *program* is executed by the shell as-if by system(3),
+  its standard output stream parsed as an arithmetic expression (like `zram-size`/`zram-resident-limit`),
+  then the result is remembered into *variable*,
+  usable in later `set!`s and `zram-size`s/`zram-resident-limit`s.
 
 ## ENVIRONMENT VARIABLES
 

--- a/tests/02-zstd/etc/systemd/zram-generator.conf
+++ b/tests/02-zstd/etc/systemd/zram-generator.conf
@@ -1,4 +1,8 @@
+set!top = echo 3
+set!bottom = echo 4
+set!ratio = ! echo top / bottom
+
 [zram0]
 compression-algorithm = zstd
 host-memory-limit = 2050
-zram-size = ram * 0.75
+zram-size = ram * ratio

--- a/tests/02-zstd/etc/systemd/zram-generator.conf
+++ b/tests/02-zstd/etc/systemd/zram-generator.conf
@@ -5,4 +5,5 @@ set!ratio = ! echo top / bottom
 [zram0]
 compression-algorithm = zstd
 host-memory-limit = 2050
+zram-resident-limit = 9999
 zram-size = ram * ratio

--- a/tests/10-example/bin/xenstore-read
+++ b/tests/10-example/bin/xenstore-read
@@ -1,0 +1,2 @@
+#!/bin/sh -x
+echo 2

--- a/tests/10-example/bin/xenstore-read
+++ b/tests/10-example/bin/xenstore-read
@@ -1,2 +1,2 @@
 #!/bin/sh -x
-echo 2
+echo '8 * 1024'  # MB

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -4,8 +4,11 @@ use zram_generator::{config, generator};
 
 use anyhow::Result;
 use fs_extra::dir::{copy, CopyOptions};
+use std::env;
+use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Write};
+use std::os::unix::ffi::OsStringExt;
 use std::path::Path;
 use std::process::{exit, Command};
 use tempfile::TempDir;
@@ -43,6 +46,15 @@ fn unshorn() {
         .unwrap();
     fs::create_dir("/proc/self").unwrap();
     symlink("zram-generator", "/proc/self/exe").unwrap();
+
+    let mut path = env::var_os("PATH")
+        .map(|p| p.to_os_string().into_vec())
+        .unwrap_or(b"/usr/bin:/bin".to_vec()); // _PATH_DEFPATH
+    path.insert(0, b':');
+    for &b in "tests/10-example/bin".as_bytes().into_iter().rev() {
+        path.insert(0, b);
+    }
+    env::set_var("PATH", OsString::from_vec(path));
 }
 
 fn prepare_directory(srcroot: &Path) -> Result<TempDir> {
@@ -123,7 +135,9 @@ fn test_02_zstd() {
     let d = &devices[0];
     assert!(d.is_swap());
     assert_eq!(d.host_memory_limit_mb, Some(2050));
-    assert_eq!(d.zram_size.as_ref().map(z_s_name), Some("ram * 0.75"));
+    assert_eq!(d.zram_size.as_ref().map(z_s_name), Some("ram * ratio"));
+    assert_eq!(d.disksize, 614989824);
+
     assert_eq!(
         d.compression_algorithms,
         config::Algorithms {
@@ -131,6 +145,7 @@ fn test_02_zstd() {
             ..Default::default()
         }
     );
+
     assert_eq!(d.options, "discard");
 }
 

--- a/zram-generator.conf.example
+++ b/zram-generator.conf.example
@@ -31,7 +31,7 @@ zram-size = min(ram / 10, 2048)
 # then this device will not consume more than 128 MiB.
 #
 # 0 means no limit; this is the default.
-zram-resident-limit = 0
+zram-resident-limit = maxhotplug * 3/4
 
 # The compression algorithm to use for the zram device,
 # or leave unspecified to keep the kernel default.

--- a/zram-generator.conf.example
+++ b/zram-generator.conf.example
@@ -1,6 +1,12 @@
 # This file is part of the zram-generator project
 # https://github.com/systemd/zram-generator
 
+# At the top level, a set!variable = program
+# directive executes /bin/sh -c program,
+# parses the output as an expression, and remembers it in variable,
+# usable in later set! and zram-size/zram-resident-limit.
+set!maxhotplug = xenstore-read /local/domain/$(xenstore-read domid)/memory/hotplug-max
+
 [zram0]
 # This section describes the settings for /dev/zram0.
 #


### PR DESCRIPTION
Rebased version of #203 with tests added.