### PR TITLE
Let the swap unit remain survive shutdown

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -226,8 +226,12 @@ fn handle_zram_swap(output_directory: &Path, device: &Device) -> Result<()> {
 [Unit]
 Description=Compressed Swap on /dev/{zram_device}
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@{zram_device}.service
 After=systemd-zram-setup@{zram_device}.service
+Before=swap.target
 
 [Swap]
 What=/dev/{zram_device}

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -217,6 +217,16 @@ fn handle_zram_swap(output_directory: &Path, device: &Device) -> Result<()> {
 
     handle_zram_bindings(output_directory, device, "dev-%i.swap")?;
 
+    let shutdown_conflicts = if device.writeback_dev.is_some() {
+        // We need to shut down the zram device to disconnect the writeback device.
+        // Once https://github.com/systemd/systemd/issues/35303 is resolved, we
+        // may revisit this and rely on the systemd to pull down the device stack
+        // if appropriate.
+        "Conflicts=shutdown.target\n"
+    } else {
+        ""
+    };
+
     /* dev-zramX.swap */
     write_contents(
         output_directory,
@@ -232,7 +242,7 @@ DefaultDependencies=no
 Requires=systemd-zram-setup@{zram_device}.service
 After=systemd-zram-setup@{zram_device}.service
 Before=swap.target
-
+{shutdown_conflicts}
 [Swap]
 What=/dev/{zram_device}
 Priority={swap_priority}
@@ -241,6 +251,7 @@ Options={options}
             zram_device = device.name,
             swap_priority = device.swap_priority,
             options = device.options.replace('%', "%%"),
+            shutdown_conflicts = shutdown_conflicts,
         ),
     )?;
 

--- a/tests/01-basic/run.expected/units/dev-zram0.swap
+++ b/tests/01-basic/run.expected/units/dev-zram0.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram0
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram0.service
 After=systemd-zram-setup@zram0.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram0

--- a/tests/02-zstd/run.expected/units/dev-zram0.swap
+++ b/tests/02-zstd/run.expected/units/dev-zram0.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram0
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram0.service
 After=systemd-zram-setup@zram0.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram0

--- a/tests/04-dropins/run.expected/units/dev-zram0.swap
+++ b/tests/04-dropins/run.expected/units/dev-zram0.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram0
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram0.service
 After=systemd-zram-setup@zram0.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram0

--- a/tests/04-dropins/run.expected/units/dev-zram2.swap
+++ b/tests/04-dropins/run.expected/units/dev-zram2.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram2
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram2.service
 After=systemd-zram-setup@zram2.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram2

--- a/tests/06-kernel-enabled/run.expected/units/dev-zram0.swap
+++ b/tests/06-kernel-enabled/run.expected/units/dev-zram0.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram0
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram0.service
 After=systemd-zram-setup@zram0.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram0

--- a/tests/09-zram-size/run.expected/units/dev-zram0.swap
+++ b/tests/09-zram-size/run.expected/units/dev-zram0.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram0
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram0.service
 After=systemd-zram-setup@zram0.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram0

--- a/tests/10-example/run.expected/units/dev-zram0.swap
+++ b/tests/10-example/run.expected/units/dev-zram0.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram0
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram0.service
 After=systemd-zram-setup@zram0.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram0

--- a/tests/10-example/run.expected/units/dev-zram0.swap
+++ b/tests/10-example/run.expected/units/dev-zram0.swap
@@ -9,6 +9,7 @@ DefaultDependencies=no
 Requires=systemd-zram-setup@zram0.service
 After=systemd-zram-setup@zram0.service
 Before=swap.target
+Conflicts=shutdown.target
 
 [Swap]
 What=/dev/zram0

--- a/tests/11-obsolete/run.expected/units/dev-zram0.swap
+++ b/tests/11-obsolete/run.expected/units/dev-zram0.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram0
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram0.service
 After=systemd-zram-setup@zram0.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram0

--- a/tests/11-obsolete/run.expected/units/dev-zram1.swap
+++ b/tests/11-obsolete/run.expected/units/dev-zram1.swap
@@ -3,8 +3,12 @@
 [Unit]
 Description=Compressed Swap on /dev/zram1
 Documentation=man:zram-generator(8) man:zram-generator.conf(5)
+
+DefaultDependencies=no
+
 Requires=systemd-zram-setup@zram1.service
 After=systemd-zram-setup@zram1.service
+Before=swap.target
 
 [Swap]
 What=/dev/zram1


### PR DESCRIPTION
Swap units have automatic dependencies of Before=swap.target,shutdown.target, Conflicts=shutdown.target. By adding DefaultDependencies=no, Before=swap.target, we effective drop the negative dependency with shutdown.target and allow the swap device to survive shutdown.

There is no need to bring down the swap device during shutdown. This wastes work, because any remaning pages need to be dropped or decompressed and moved to normal memory. Normally this is very quick, but the report says that it takes 15–20 seconds in their case.

Closes https://github.com/systemd/zram-generator/issues/191.