### PR TITLE
Replace clap with getopts, bump ctor like in #208

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests/07a-mount-point-excl", "tests/10-example"]
 
 [dependencies]
 anyhow = "1.0.12"
-clap = { version = "2.33", default-features = false }
+getopts = "0.2"
 liboverdrop = "0.1.0"
 rust-ini = ">=0.15, <0.18"
 log = { version = "0.4", features = ["std"] }


### PR DESCRIPTION
The parser is equivalent to the one post-#208, except

With clap:

    $ l target/release/zram-generator
    -rwxr-xr-x 2 nabijaczleweli users 762.5k 11-27 15:40 target/release/zram-generator
    $ size target/release/zram-generator
       text    data     bss     dec     hex filename
     740420   30177     392  770989   bc3ad target/release/zram-generator

Without:

    $ size target/release/zram-generator
       text    data     bss     dec     hex filename
     577136   24457     392  601985   92f81 target/release/zram-generator
    $ l target/release/zram-generator
    -rwxr-xr-x 2 nabijaczleweli users 598.5k 11-27 16:17 target/release/zram-generator

And the dependency tree isn't infinitely large.