### PR TITLE
Cargo.toml: update ctor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ fasteval = { version = "0.2", default-features = false }
 tempfile = "3"
 fs_extra = "1.3"
 nix = ">=0.22, <0.24"
-ctor = "0.1"
+ctor = "0.2"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Current is 0.2.9. The previous version conflicts with the newest clap in:
  cargo check --features clap/deprecated

With this update, the check can be run and returns no warnigns.