### PR TITLE
Cargo.toml: allow rust-ini 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests/07a-mount-point-excl", "tests/10-example"]
 anyhow = "1.0.12"
 clap = { version = "4.5", default-features = false, features = ["std", "cargo", "help", "error-context"] }
 liboverdrop = "0.1.0"
-rust-ini = ">=0.15, <0.18"
+rust-ini = ">=0.15, <0.19"
 log = { version = "0.4", features = ["std"] }
 fasteval = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
This is what Fedora has. Seems to compile just fine.