### PR TITLE
Update Debian installation instructions for Bookworm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ generator in rust.
 It is recommended to use an existing package:
 
 * Fedora: `sudo dnf install zram-generator-defaults` (or `sudo dnf install zram-generator` to install without the default configuration)
-* Debian: packages provided by nabijaczleweli, see https://debian.nabijaczleweli.xyz/README.
+* Debian: For Debian 12 Bookworm or later, install `systemd-zram-generator` from the official Debian repos. For earlier Debian releases, packages are provided by nabijaczleweli, see https://debian.nabijaczleweli.xyz/README.
 * Arch: `sudo pacman -S zram-generator` (or https://aur.archlinux.org/packages/zram-generator-git/ for the latest git commit)
 
 To install directly from sources, execute `make build && sudo make install NOBUILD=true`:


### PR DESCRIPTION
The `systemd-zram-generator` package is available in the official Debian repos as of Debian 12 (Bookworm). This should be the preferred installation source for Debian 12 or later.

https://packages.debian.org/search?keywords=systemd-zram-generator