### PR TITLE
Fix X-mount README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In case you want this path to be user-writable, since util-linux v2.39 you can u
 [zram1]
 options = X-mount.mode=1777
 ```
-(and/or the relevant `X.mount.{owner,group}=` arguments, cf. mount(8)).
+(and/or the relevant `X-mount.{owner,group}=` arguments, cf. mount(8)).
 
 Otherwise, you can use the following "high-quality hack":
 for the above example, create an


### PR DESCRIPTION
Replaces typo `.` with `-` in the `X-mount.{owner,group}=` documentation.

See

- https://www.kernel.org/pub/linux/utils/util-linux/v2.39/v2.39-ReleaseNotes
- https://github.com/util-linux/util-linux/commit/722c96974dd4009a334e4aee556eedaab5fb94b4
- https://github.com/systemd/zram-generator/commit/1c0aa9cf1fa96e044244059038d0b4d26c1afacd