### PR TITLE
Bump rust-ini to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests/07a-mount-point-excl", "tests/10-example"]
 anyhow = "1.0.12"
 clap = { version = "4.5", default-features = false, features = ["std", "cargo", "help", "error-context"] }
 liboverdrop = "0.1.0"
-rust-ini = ">=0.15, <0.19"
+rust-ini = "0.21"
 log = { version = "0.4", features = ["std"] }
 fasteval = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
Probably worth adding the `Cargo.lock` file, that is the current recommended workflow.