### PR TITLE
Bump nix from 0.22 to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ fasteval = { version = "0.2", default-features = false }
 [dev-dependencies]
 tempfile = "3"
 fs_extra = "1.3"
-nix = ">=0.22, <0.24"
+nix = { version = "0.30", features = ["mount", "sched", "user"] }
 ctor = "0.2"
 
 [profile.release]


### PR DESCRIPTION
This requires enabling some feature flags that are no longer enabled by default, but no actual code changes.
